### PR TITLE
Make paginated topic content queries more performant

### DIFF
--- a/src/main/java/org/atlasapi/persistence/MongoContentPersistenceModule.java
+++ b/src/main/java/org/atlasapi/persistence/MongoContentPersistenceModule.java
@@ -237,7 +237,7 @@ public class MongoContentPersistenceModule implements ContentPersistenceModule {
     }
     
     public @Primary @Bean MongoContentLister contentLister() {
-        return new MongoContentLister(db);
+        return new MongoContentLister(db, knownTypeContentResolver());
     }
 
     public @Primary @Bean TopicStore topicStore() {

--- a/src/test/java/org/atlasapi/persistence/content/mongo/MongoContentListerTest.java
+++ b/src/test/java/org/atlasapi/persistence/content/mongo/MongoContentListerTest.java
@@ -23,6 +23,7 @@ import org.atlasapi.persistence.audit.PerHourAndDayMongoPersistenceAuditLog;
 import org.atlasapi.persistence.audit.PersistenceAuditLog;
 import org.atlasapi.persistence.content.listing.ContentListingProgress;
 import org.atlasapi.persistence.lookup.NewLookupWriter;
+import org.atlasapi.persistence.lookup.mongo.MongoLookupEntryStore;
 import org.atlasapi.persistence.player.PlayerResolver;
 import org.atlasapi.persistence.service.ServiceResolver;
 import org.joda.time.DateTime;
@@ -37,6 +38,7 @@ import com.metabroadcast.common.persistence.MongoTestHelper;
 import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
 import com.metabroadcast.common.time.DateTimeZones;
 import com.metabroadcast.common.time.SystemClock;
+import com.mongodb.ReadPreference;
 
 @RunWith( MockitoJUnitRunner.class )
 public class MongoContentListerTest {
@@ -51,7 +53,9 @@ public class MongoContentListerTest {
     private static final DatabasedMongo mongo = MongoTestHelper.anEmptyTestDatabase();
     private static final PersistenceAuditLog persistenceAuditLog = new PerHourAndDayMongoPersistenceAuditLog(mongo);
     
-    private final MongoContentLister lister = new MongoContentLister(mongo);
+    private final MongoContentLister lister = new MongoContentLister(mongo, 
+            new MongoContentResolver(mongo, new MongoLookupEntryStore(
+                    mongo.collection("lookup"), persistenceAuditLog, ReadPreference.primary())));
 
     private static final ServiceResolver serviceResolver = mock(ServiceResolver.class);
     private static final PlayerResolver playerResolver = mock(PlayerResolver.class);


### PR DESCRIPTION
Previously, we would iterate over all content in previous
pages of results, and throw them away before returning
the requested page of results. This is rather heap-heavy.
Now, we resolve all LookupRefs, and then only resolve
Content that matches the requested Selection.