### PR TITLE
Add activelyPublished flag to LookupEntry

### DIFF
--- a/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntry.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntry.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.atlasapi.media.entity.Alias;
-import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Described;
 import org.atlasapi.media.entity.LookupRef;
 import org.joda.time.DateTime;
@@ -21,7 +20,7 @@ public class LookupEntry {
         DateTime now = new DateTime(DateTimeZones.UTC);
         LookupRef lookupRef = LookupRef.from(c);
         ImmutableSet<LookupRef> reflexiveSet = ImmutableSet.of(lookupRef);
-        return new LookupEntry(c.getCanonicalUri(), c.getId(), lookupRef, c.getAllUris(), c.getAliases(), reflexiveSet, reflexiveSet, reflexiveSet, now, now);
+        return new LookupEntry(c.getCanonicalUri(), c.getId(), lookupRef, c.getAllUris(), c.getAliases(), reflexiveSet, reflexiveSet, reflexiveSet, now, now, c.isActivelyPublished());
     }
     
     public static Function<LookupEntry,String> TO_ID = new Function<LookupEntry, String>() {
@@ -65,8 +64,9 @@ public class LookupEntry {
     private final DateTime updated;
 
     private final LookupRef self;
+    private final boolean activelyPublished;
 
-    public LookupEntry(String uri, Long id, LookupRef self, Set<String> aliasUris, Set<Alias> aliases, Set<LookupRef> directEquivs, Set<LookupRef> explicit, Set<LookupRef> equivs, DateTime created, DateTime updated) {
+    public LookupEntry(String uri, Long id, LookupRef self, Set<String> aliasUris, Set<Alias> aliases, Set<LookupRef> directEquivs, Set<LookupRef> explicit, Set<LookupRef> equivs, DateTime created, DateTime updated, boolean activelyPublished) {
         this.uri = uri;
         this.id = id;
         this.self = self;
@@ -77,6 +77,7 @@ public class LookupEntry {
         this.equivs = ImmutableSet.copyOf(equivs);
         this.created = created;
         this.updated = updated;
+        this.activelyPublished = activelyPublished;
     }
 
     public String uri() {
@@ -87,6 +88,10 @@ public class LookupEntry {
         return id;
     }
 
+    public boolean activelyPublished() {
+        return activelyPublished;
+    }
+    
     public Set<String> aliasUrls() {
         return aliasUris;
     }
@@ -105,7 +110,7 @@ public class LookupEntry {
 
     public LookupEntry copyWithExplicitEquivalents(Iterable<LookupRef> newExplicits) {
         List<LookupRef> explicit = ImmutableList.<LookupRef>builder().addAll(newExplicits).add(self).build();
-        return new LookupEntry(uri, id, self, aliasUris, aliases, directEquivalents, ImmutableSet.copyOf(explicit), this.equivs, created, new DateTime(DateTimeZones.UTC));
+        return new LookupEntry(uri, id, self, aliasUris, aliases, directEquivalents, ImmutableSet.copyOf(explicit), this.equivs, created, new DateTime(DateTimeZones.UTC), activelyPublished);
     }
     
     public Set<LookupRef> equivalents() {
@@ -114,7 +119,7 @@ public class LookupEntry {
 
     public LookupEntry copyWithEquivalents(Iterable<LookupRef> newEquivs) {
         Set<LookupRef> equivs = ImmutableSet.<LookupRef>builder().addAll(newEquivs).add(self).build();
-        return new LookupEntry(uri, id, self, aliasUris, aliases, directEquivalents, explicit, equivs, created, new DateTime(DateTimeZones.UTC));
+        return new LookupEntry(uri, id, self, aliasUris, aliases, directEquivalents, explicit, equivs, created, new DateTime(DateTimeZones.UTC), activelyPublished);
     }
     
     public Set<LookupRef> directEquivalents() {
@@ -123,7 +128,7 @@ public class LookupEntry {
     
     public LookupEntry copyWithDirectEquivalents(Iterable<LookupRef> directEquivalents) {
         List<LookupRef> dequivs = ImmutableList.<LookupRef>builder().addAll(directEquivalents).add(self).build();
-        return new LookupEntry(uri, id, self, aliasUris, aliases, ImmutableSet.copyOf(dequivs), explicit, equivs, created, new DateTime(DateTimeZones.UTC));
+        return new LookupEntry(uri, id, self, aliasUris, aliases, ImmutableSet.copyOf(dequivs), explicit, equivs, created, new DateTime(DateTimeZones.UTC), activelyPublished);
     }
 
     public DateTime created() {
@@ -145,7 +150,8 @@ public class LookupEntry {
         }
         if(that instanceof LookupEntry) {
             LookupEntry other = (LookupEntry) that;
-            return uri.equals(other.uri) && equivs.equals(other.equivs) && created.equals(other.created) && updated.equals(other.updated);
+            return uri.equals(other.uri) && equivs.equals(other.equivs) && created.equals(other.created) && updated.equals(other.updated) 
+                    && activelyPublished == other.activelyPublished;
         }
         return false;
     }

--- a/src/main/java/org/atlasapi/persistence/lookup/mongo/LookupEntryTranslator.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/mongo/LookupEntryTranslator.java
@@ -27,6 +27,7 @@ public class LookupEntryTranslator {
     private static final String EQUIVS = "equivs";
     private static final String LAST_UPDATED = "updated";
     private static final String FIRST_CREATED = "created";
+    public static final String ACTIVELY_PUBLISHED = "activelyPublished";
     public static final String ALIASES = "aliases";
     public static final String IDS = "ids";
     public static final String OPAQUE_ID = "aid";
@@ -69,6 +70,10 @@ public class LookupEntryTranslator {
         TranslatorUtils.fromDateTime(dbo, FIRST_CREATED, entry.created());
         TranslatorUtils.fromDateTime(dbo, LAST_UPDATED, entry.updated());
         
+        if (!entry.activelyPublished()) {
+            TranslatorUtils.from(dbo, ACTIVELY_PUBLISHED, entry.activelyPublished());
+        }
+        
         return dbo;
     }
 
@@ -106,7 +111,11 @@ public class LookupEntryTranslator {
         DateTime created = TranslatorUtils.toDateTime(dbo, FIRST_CREATED);
         DateTime updated = TranslatorUtils.toDateTime(dbo, LAST_UPDATED);
         
-        return new LookupEntry(uri, id, self, aliasUris, aliases, directEquivalents, explicitEquivalents, equivs, created, updated);
+        boolean activelyPublished = true;
+        if (dbo.containsField(ACTIVELY_PUBLISHED)) {
+            activelyPublished = TranslatorUtils.toBoolean(dbo, ACTIVELY_PUBLISHED);
+        }
+        return new LookupEntry(uri, id, self, aliasUris, aliases, directEquivalents, explicitEquivalents, equivs, created, updated, activelyPublished);
     }
     
     public DBObject removeFieldsForHash(DBObject dbo) {

--- a/src/main/java/org/atlasapi/persistence/lookup/mongo/MongoLookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/mongo/MongoLookupEntryStore.java
@@ -128,9 +128,9 @@ public class MongoLookupEntryStore implements LookupEntryStore, NewLookupWriter 
             store(newEntry, existing);
         } else if(!newEntry.lookupRef().category().equals(existing.lookupRef().category())) {
             updateEntry(content, newEntry, existing);
-        } else if (!newEntry.aliasUrls().equals(existing.aliasUrls())) {
-            store(merge(content, newEntry, existing), existing);
-        } else if (!newEntry.aliases().equals(existing.aliases())) {
+        } else if (!newEntry.aliasUrls().equals(existing.aliasUrls())
+                || !newEntry.aliases().equals(existing.aliases())
+                || newEntry.activelyPublished() != existing.activelyPublished()) {
             store(merge(content, newEntry, existing), existing);
         } 
     }

--- a/src/test/java/org/atlasapi/persistence/lookup/mongo/LookupEntryHasherTest.java
+++ b/src/test/java/org/atlasapi/persistence/lookup/mongo/LookupEntryHasherTest.java
@@ -40,7 +40,8 @@ public class LookupEntryHasherTest {
                 ImmutableSet.<LookupRef>of(),
                 ImmutableSet.<LookupRef>of(),
                 created,
-                updated);
+                updated,
+                true);
                 
                 
                 

--- a/src/test/java/org/atlasapi/persistence/lookup/mongo/LookupEntryTranslatorTest.java
+++ b/src/test/java/org/atlasapi/persistence/lookup/mongo/LookupEntryTranslatorTest.java
@@ -2,6 +2,7 @@ package org.atlasapi.persistence.lookup.mongo;
 
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -24,6 +25,7 @@ import com.mongodb.DBObject;
 
 public class LookupEntryTranslatorTest {
 
+    private static final String ACTIVELY_PUBLISHED = "activelyPublished";
     private final LookupEntryTranslator translator
         = new LookupEntryTranslator();
     
@@ -47,9 +49,15 @@ public class LookupEntryTranslatorTest {
         DateTime created = DateTime.now(DateTimeZones.UTC);
         DateTime updated = DateTime.now(DateTimeZones.UTC);
         
-        LookupEntry e = new LookupEntry("uri", 1L, self, aliasUris, aliases, directEquivs, explicit, equivs, created, updated);
+        boolean activelyPublished = true;
+        
+        LookupEntry e = new LookupEntry("uri", 1L, self, aliasUris, aliases, directEquivs, explicit, equivs, created, updated, activelyPublished );
         
         DBObject dbo = translator.toDbo(e);
+        
+        // not stored if true, since this is the common case, and we don't want 
+        // to write all records unnecessarily when this field has been added
+        assertFalse(dbo.containsField(ACTIVELY_PUBLISHED));
         
         LookupEntry t = translator.fromDbo(dbo);
         
@@ -63,6 +71,15 @@ public class LookupEntryTranslatorTest {
         assertEquals(e.equivalents(), t.equivalents());
         assertEquals(e.created(), t.created());
         assertEquals(e.updated(), t.updated());
+        assertEquals(e.activelyPublished(), t.activelyPublished());
+        
+        e = new LookupEntry("uri", 1L, self, aliasUris, aliases, directEquivs, explicit, equivs, created, updated, false);
+        dbo = translator.toDbo(e);
+        
+        assertTrue(dbo.containsField(ACTIVELY_PUBLISHED));
+        
+        t = translator.fromDbo(dbo);
+        assertEquals(e.activelyPublished(), t.activelyPublished());
         
     }
     
@@ -86,7 +103,8 @@ public class LookupEntryTranslatorTest {
         DateTime created = DateTime.now(DateTimeZones.UTC);
         DateTime updated = DateTime.now(DateTimeZones.UTC);
         
-        LookupEntry e = new LookupEntry("uri", 1L, self, aliasUris, aliases, directEquivs, explicit, equivs, created, updated);
+        boolean activelyPublished = true;
+        LookupEntry e = new LookupEntry("uri", 1L, self, aliasUris, aliases, directEquivs, explicit, equivs, created, updated, activelyPublished);
         
         DBObject dbo = translator.toDbo(e);
         

--- a/src/test/java/org/atlasapi/persistence/lookup/mongo/MongoLookupEntryStoreTest.java
+++ b/src/test/java/org/atlasapi/persistence/lookup/mongo/MongoLookupEntryStoreTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -372,5 +373,21 @@ public class MongoLookupEntryStoreTest {
                                  "Hash code not changed for URI {}; skipping write"), 
                 arg1captor.getAllValues()
         );
+    }
+    
+    @Test
+    public void testEnsureLookupWritesWhenActivelyPublishedChanges() {
+        
+        Item item = new Item("http://example.org/item", "testItem1Curie", Publisher.BBC);
+        
+        entryStore.ensureLookup(item);
+        LookupEntry entry = Iterables.getOnlyElement(entryStore.entriesForCanonicalUris(ImmutableList.of(item.getCanonicalUri())));
+        assertTrue(entry.activelyPublished());
+        
+        item.setActivelyPublished(false);
+        entryStore.ensureLookup(item);
+
+        entry = Iterables.getOnlyElement(entryStore.entriesForCanonicalUris(ImmutableList.of(item.getCanonicalUri())));
+        assertFalse(entry.activelyPublished());
     }
 }


### PR DESCRIPTION
When iterating over content for a publisher, we need to
filter for those that aren't actively published. This
requires activelyPublished on LookupEntry so we can
query in mongo, rather than apply a post filter, which
causes problems with pagination.