### PR TITLE
Remove related links if not set

### DIFF
--- a/src/main/java/org/atlasapi/persistence/media/entity/DescribedTranslator.java
+++ b/src/main/java/org/atlasapi/persistence/media/entity/DescribedTranslator.java
@@ -50,7 +50,7 @@ public class DescribedTranslator implements ModelTranslator<Described> {
     public static final String MEDIUM_DESC_KEY = "mediumDescription";
     public static final String LONG_DESC_KEY = "longDescription";
     public static final String ACTIVELY_PUBLISHED_KEY = "activelyPublished";
-    private static final String LINKS_KEY = "links";
+    public static final String LINKS_KEY = "links";
     protected static final String LOCALIZED_DESCRIPTIONS_KEY = "descriptions";
     protected static final String LOCALIZED_TITLES_KEY = "titles";
     protected static final String REVIEWS_KEY = "reviews";


### PR DESCRIPTION
we perform a `set` on containers when saving, so we need to explicitly `unset` fields to remove them. Ugh.