### PR TITLE
List entries for publishers regardless of whether they are published

### DIFF
--- a/src/main/java/org/atlasapi/persistence/lookup/InMemoryLookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/InMemoryLookupEntryStore.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.persistence.content.listing.ContentListingCriteria;
+import org.atlasapi.persistence.content.listing.ContentListingProgress;
 import org.atlasapi.persistence.lookup.entry.LookupEntry;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 
@@ -91,7 +91,8 @@ public class InMemoryLookupEntryStore implements LookupEntryStore {
     }
 
     @Override
-    public Iterable<LookupEntry> allEntriesForPublishers(ContentListingCriteria criteria) {
+    public Iterable<LookupEntry> allEntriesForPublishers(Iterable<Publisher> publishers,
+            ContentListingProgress progress) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/org/atlasapi/persistence/lookup/InMemoryLookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/InMemoryLookupEntryStore.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.persistence.content.listing.ContentListingProgress;
+import org.atlasapi.persistence.content.listing.ContentListingCriteria;
 import org.atlasapi.persistence.lookup.entry.LookupEntry;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 
@@ -91,8 +91,8 @@ public class InMemoryLookupEntryStore implements LookupEntryStore {
     }
 
     @Override
-    public Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers,
-            ContentListingProgress progress, boolean onlyActivelyPublished) {
+    public Iterable<LookupEntry> entriesForPublishers(ContentListingCriteria criteria,
+            boolean onlyActivelyPublished) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/org/atlasapi/persistence/lookup/InMemoryLookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/InMemoryLookupEntryStore.java
@@ -89,4 +89,15 @@ public class InMemoryLookupEntryStore implements LookupEntryStore {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers,
+            boolean onlyActivelyPublished) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers,
+            boolean onlyActivelyPublished, Selection selection) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/main/java/org/atlasapi/persistence/lookup/InMemoryLookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/InMemoryLookupEntryStore.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.persistence.content.listing.ContentListingProgress;
 import org.atlasapi.persistence.lookup.entry.LookupEntry;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 
@@ -91,13 +92,7 @@ public class InMemoryLookupEntryStore implements LookupEntryStore {
 
     @Override
     public Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers,
-            boolean onlyActivelyPublished) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers,
-            boolean onlyActivelyPublished, Selection selection) {
+            ContentListingProgress progress, boolean onlyActivelyPublished) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/org/atlasapi/persistence/lookup/InMemoryLookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/InMemoryLookupEntryStore.java
@@ -91,8 +91,7 @@ public class InMemoryLookupEntryStore implements LookupEntryStore {
     }
 
     @Override
-    public Iterable<LookupEntry> entriesForPublishers(ContentListingCriteria criteria,
-            boolean onlyActivelyPublished) {
+    public Iterable<LookupEntry> allEntriesForPublishers(ContentListingCriteria criteria) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
@@ -3,6 +3,7 @@ package org.atlasapi.persistence.lookup.entry;
 import java.util.Map;
 
 import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.persistence.content.listing.ContentListingProgress;
 
 import com.google.common.base.Optional;
 import com.metabroadcast.common.query.Selection;
@@ -46,18 +47,10 @@ public interface LookupEntryStore {
 
     Iterable<LookupEntry> entriesForIds(Iterable<Long> ids);
 
-    /**
-     * @deprecated Use {@link LookupEntryStore#entriesForPublishers(Iterable, boolean)} or
-     * {@link LookupEntryStore#entriesForPublishers(Iterable, boolean, Selection)}
-     */
-    @Deprecated
     Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers, Selection selection);
 
     Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers,
-            boolean onlyActivelyPublished);
+            ContentListingProgress progress, boolean onlyActivelyPublished);
 
-    Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers,
-            boolean onlyActivelyPublished, Selection selection);
-    
     Map<String, Long> idsForCanonicalUris(Iterable<String> uris);
 }

--- a/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
@@ -3,7 +3,7 @@ package org.atlasapi.persistence.lookup.entry;
 import java.util.Map;
 
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.persistence.content.listing.ContentListingProgress;
+import org.atlasapi.persistence.content.listing.ContentListingCriteria;
 
 import com.google.common.base.Optional;
 import com.metabroadcast.common.query.Selection;
@@ -49,8 +49,8 @@ public interface LookupEntryStore {
 
     Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers, Selection selection);
 
-    Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers,
-            ContentListingProgress progress, boolean onlyActivelyPublished);
+    Iterable<LookupEntry> entriesForPublishers(ContentListingCriteria criteria,
+            boolean onlyActivelyPublished);
 
     Map<String, Long> idsForCanonicalUris(Iterable<String> uris);
 }

--- a/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
@@ -49,8 +49,7 @@ public interface LookupEntryStore {
 
     Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers, Selection selection);
 
-    Iterable<LookupEntry> entriesForPublishers(ContentListingCriteria criteria,
-            boolean onlyActivelyPublished);
+    Iterable<LookupEntry> allEntriesForPublishers(ContentListingCriteria criteria);
 
     Map<String, Long> idsForCanonicalUris(Iterable<String> uris);
 }

--- a/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
@@ -3,7 +3,7 @@ package org.atlasapi.persistence.lookup.entry;
 import java.util.Map;
 
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.persistence.content.listing.ContentListingCriteria;
+import org.atlasapi.persistence.content.listing.ContentListingProgress;
 
 import com.google.common.base.Optional;
 import com.metabroadcast.common.query.Selection;
@@ -49,7 +49,8 @@ public interface LookupEntryStore {
 
     Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers, Selection selection);
 
-    Iterable<LookupEntry> allEntriesForPublishers(ContentListingCriteria criteria);
+    Iterable<LookupEntry> allEntriesForPublishers(Iterable<Publisher> publishers,
+            ContentListingProgress progress);
 
     Map<String, Long> idsForCanonicalUris(Iterable<String> uris);
 }

--- a/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
@@ -46,7 +46,18 @@ public interface LookupEntryStore {
 
     Iterable<LookupEntry> entriesForIds(Iterable<Long> ids);
 
+    /**
+     * @deprecated Use {@link LookupEntryStore#entriesForPublishers(Iterable, boolean)} or
+     * {@link LookupEntryStore#entriesForPublishers(Iterable, boolean, Selection)}
+     */
+    @Deprecated
     Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers, Selection selection);
+
+    Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers,
+            boolean onlyActivelyPublished);
+
+    Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers,
+            boolean onlyActivelyPublished, Selection selection);
     
     Map<String, Long> idsForCanonicalUris(Iterable<String> uris);
 }

--- a/src/main/java/org/atlasapi/persistence/lookup/mongo/MongoLookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/mongo/MongoLookupEntryStore.java
@@ -238,9 +238,8 @@ public class MongoLookupEntryStore implements LookupEntryStore, NewLookupWriter 
     }
 
     @Override
-    public Iterable<LookupEntry> entriesForPublishers(ContentListingCriteria criteria,
-            boolean onlyActivelyPublished) {
-        DBCursor cursor = cursorForPublishers(criteria, onlyActivelyPublished);
+    public Iterable<LookupEntry> allEntriesForPublishers(ContentListingCriteria criteria) {
+        DBCursor cursor = cursorForPublishers(criteria);
         return Iterables.transform(cursor, translator.FROM_DBO);
     }
 
@@ -248,8 +247,7 @@ public class MongoLookupEntryStore implements LookupEntryStore, NewLookupWriter 
         return Iterables.transform(lookup.find(), translator.FROM_DBO);
     }
 
-    private DBCursor cursorForPublishers(ContentListingCriteria criteria,
-            boolean onlyActivelyPublished) {
+    private DBCursor cursorForPublishers(ContentListingCriteria criteria) {
         MongoQueryBuilder queryBuilder = where()
                 .fieldIn(PUBLISHER, Iterables.transform(criteria.getPublishers(), Publisher.TO_KEY))
                 .fieldIn(
@@ -259,12 +257,6 @@ public class MongoLookupEntryStore implements LookupEntryStore, NewLookupWriter 
 
         if (!criteria.getProgress().equals(ContentListingProgress.START)) {
             queryBuilder.fieldGreaterThan(ID, criteria.getProgress().getUri());
-        }
-
-        if (onlyActivelyPublished) {
-            // Not actively published content will have this value set to false
-            // Actively published content will either have this value be true or null
-            queryBuilder.fieldNotEqualTo(ACTIVELY_PUBLISHED, false);
         }
 
         return lookup.find(queryBuilder.build())

--- a/src/test/java/org/atlasapi/persistence/lookup/mongo/MongoLookupEntryStoreTest.java
+++ b/src/test/java/org/atlasapi/persistence/lookup/mongo/MongoLookupEntryStoreTest.java
@@ -410,12 +410,11 @@ public class MongoLookupEntryStoreTest {
         entryStore.store(shouldReturnSecond);
         entryStore.store(shouldNotReturn);
 
-        Iterable<LookupEntry> entries = entryStore.entriesForPublishers(
+        Iterable<LookupEntry> entries = entryStore.allEntriesForPublishers(
                 ContentListingCriteria.defaultCriteria()
                         .forPublisher(Publisher.BBC)
                         .forContent(ContentCategory.TOP_LEVEL_ITEM)
-                        .build(),
-                true
+                        .build()
         );
 
         assertThat(Iterables.size(entries), is(2));
@@ -435,42 +434,16 @@ public class MongoLookupEntryStoreTest {
         entryStore.store(published);
         entryStore.store(unpublished);
 
-        Iterable<LookupEntry> entries = entryStore.entriesForPublishers(
+        Iterable<LookupEntry> entries = entryStore.allEntriesForPublishers(
                 ContentListingCriteria.defaultCriteria()
                         .forPublisher(Publisher.BBC)
                         .forContent(ContentCategory.TOP_LEVEL_ITEM)
-                        .build(),
-                false
+                        .build()
         );
 
         assertThat(Iterables.size(entries), is(2));
         assertThat(Iterables.get(entries, 0).uri(), is(published.uri()));
         assertThat(Iterables.get(entries, 1).uri(), is(unpublished.uri()));
-    }
-
-    @Test
-    public void testEntriesForPublishersDoesNotReturnNonPublishedItemsIfNotRequested()
-            throws Exception {
-        LookupEntry published = LookupEntry.lookupEntryFrom(
-                new Item("uriA", "uriA", Publisher.BBC)
-        );
-        Item unpublishedItem = new Item("uriB", "uriB", Publisher.BBC);
-        unpublishedItem.setActivelyPublished(false);
-        LookupEntry unpublished = LookupEntry.lookupEntryFrom(unpublishedItem);
-
-        entryStore.store(published);
-        entryStore.store(unpublished);
-
-        Iterable<LookupEntry> entries = entryStore.entriesForPublishers(
-                ContentListingCriteria.defaultCriteria()
-                        .forPublisher(Publisher.BBC)
-                        .forContent(ContentCategory.TOP_LEVEL_ITEM)
-                        .build(),
-                true
-        );
-
-        assertThat(Iterables.size(entries), is(1));
-        assertThat(Iterables.get(entries, 0).uri(), is(published.uri()));
     }
 
     @Test
@@ -501,13 +474,12 @@ public class MongoLookupEntryStoreTest {
         ImmutableList<Publisher> publishers = ImmutableList.of(
                 Publisher.BBC, Publisher.METABROADCAST, Publisher.CANARY
         );
-        Iterable<LookupEntry> entries = entryStore.entriesForPublishers(
+        Iterable<LookupEntry> entries = entryStore.allEntriesForPublishers(
                 ContentListingCriteria.defaultCriteria()
                         .forPublishers(publishers)
                         .startingAt(progress)
                         .forContent(ContentCategory.TOP_LEVEL_ITEM)
-                        .build(),
-                true
+                        .build()
         );
 
         assertThat(Iterables.size(entries), is(2));
@@ -530,12 +502,11 @@ public class MongoLookupEntryStoreTest {
         ImmutableList<Publisher> publishers = ImmutableList.of(
                 Publisher.BBC, Publisher.METABROADCAST, Publisher.CANARY
         );
-        Iterable<LookupEntry> entries = entryStore.entriesForPublishers(
+        Iterable<LookupEntry> entries = entryStore.allEntriesForPublishers(
                 ContentListingCriteria.defaultCriteria()
                         .forPublishers(publishers)
                         .forContent(ContentCategory.CHILD_ITEM)
-                        .build(),
-                true
+                        .build()
         );
 
         assertThat(Iterables.size(entries), is(1));


### PR DESCRIPTION
- Deprecate existing method and create two overloaded methods to
avoid passing a null selection as a parameter