### PR TITLE
Change send message to specify partition key

### DIFF
--- a/src/main/java/org/atlasapi/persistence/content/MessageQueueingContentWriter.java
+++ b/src/main/java/org/atlasapi/persistence/content/MessageQueueingContentWriter.java
@@ -14,6 +14,7 @@ import org.atlasapi.persistence.media.entity.ItemTranslator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.primitives.Longs;
 import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
 import com.metabroadcast.common.queue.MessageSender;
 import com.metabroadcast.common.time.SystemClock;
@@ -65,7 +66,9 @@ public class MessageQueueingContentWriter implements ContentWriter {
 
     private void enqueueMessageUpdatedMessage(final Content content) {
         try {
-            sender.sendMessage(createEntityUpdatedMessage(content));
+            sender.sendMessage(
+                    createEntityUpdatedMessage(content), Longs.toByteArray(content.getId())
+            );
         } catch (Exception e) {
             log.error("update message failed: " + content, e);
         }

--- a/src/main/java/org/atlasapi/persistence/content/MessageQueuingContentGroupWriter.java
+++ b/src/main/java/org/atlasapi/persistence/content/MessageQueuingContentGroupWriter.java
@@ -10,6 +10,7 @@ import org.atlasapi.messaging.v3.EntityUpdatedMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.primitives.Longs;
 import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
 import com.metabroadcast.common.queue.MessageSender;
 import com.metabroadcast.common.queue.MessagingException;
@@ -36,7 +37,9 @@ public class MessageQueuingContentGroupWriter implements ContentGroupWriter {
     public void createOrUpdate(ContentGroup group) {
         try {
             delegate.createOrUpdate(group);
-            messageSender.sendMessage(createEntityUpdatedMessage(group));
+            messageSender.sendMessage(
+                    createEntityUpdatedMessage(group), Longs.toByteArray(group.getId())
+            );
         } catch (MessagingException e) {
             log.error("update message failed: " + group.toString(), e);
         }

--- a/src/main/java/org/atlasapi/persistence/content/schedule/mongo/MongoScheduleStore.java
+++ b/src/main/java/org/atlasapi/persistence/content/schedule/mongo/MongoScheduleStore.java
@@ -148,7 +148,7 @@ public class MongoScheduleStore implements ScheduleResolver, ScheduleWriter {
         DateTime end = interval.getEnd();
         ScheduleUpdateMessage msg = new ScheduleUpdateMessage(mid, ts, src, cid , start, end);
         try {
-            messageSender.sendMessage(msg);
+            messageSender.sendMessage(msg, msg.getChannel().getBytes());
         } catch (MessagingException e) {
             String errMsg = String.format("%s %s %s", src, cid, interval);
             log.error(errMsg, e);

--- a/src/main/java/org/atlasapi/persistence/event/MessageQueueingEventWriter.java
+++ b/src/main/java/org/atlasapi/persistence/event/MessageQueueingEventWriter.java
@@ -10,6 +10,7 @@ import org.atlasapi.messaging.v3.EntityUpdatedMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.primitives.Longs;
 import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
 import com.metabroadcast.common.queue.MessageSender;
 import com.metabroadcast.common.time.SystemClock;
@@ -51,7 +52,7 @@ public class MessageQueueingEventWriter implements EventWriter {
 
     private void enqueueMessageUpdatedEvent(Event event) {
         try {
-            sender.sendMessage(createEntityUpdatedMessage(event));
+            sender.sendMessage(createEntityUpdatedMessage(event), Longs.toByteArray(event.getId()));
         } catch (Exception e) {
             LOG.warn("Update message failed: " + event, e);
         }

--- a/src/main/java/org/atlasapi/persistence/topic/MessageQueueingTopicWriter.java
+++ b/src/main/java/org/atlasapi/persistence/topic/MessageQueueingTopicWriter.java
@@ -8,6 +8,7 @@ import org.atlasapi.messaging.v3.EntityUpdatedMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.primitives.Longs;
 import com.metabroadcast.common.ids.NumberToShortStringCodec;
 import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
 import com.metabroadcast.common.queue.MessageSender;
@@ -38,7 +39,7 @@ public class MessageQueueingTopicWriter extends ForwardingTopicStore {
     public void write(final Topic topic) {
         delegate.write(topic);
         try {
-            sender.sendMessage(createEntityUpdatedMessage(topic));
+            sender.sendMessage(createEntityUpdatedMessage(topic), Longs.toByteArray(topic.getId()));
         } catch (Exception e) {
             log.error("update message failed: " + topic, e);
         }

--- a/src/test/java/org/atlasapi/persistence/MongoContentPersistenceIntegrationTest.java
+++ b/src/test/java/org/atlasapi/persistence/MongoContentPersistenceIntegrationTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.nullValue;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.messaging.v3.KafkaMessagingModule;
 import org.atlasapi.messaging.v3.MessagingModule;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ContentWriter;
@@ -55,6 +54,12 @@ public class MongoContentPersistenceIntegrationTest {
                         @Override
                         public void sendMessage(M message)
                                 throws MessagingException {
+                        }
+
+                        @Override
+                        public void sendMessage(M m, byte[] bytes)
+                                throws MessagingException {
+
                         }
                     };
                 }

--- a/src/test/java/org/atlasapi/persistence/content/MessageQueueingContentWriterTest.java
+++ b/src/test/java/org/atlasapi/persistence/content/MessageQueueingContentWriterTest.java
@@ -2,6 +2,7 @@ package org.atlasapi.persistence.content;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -13,6 +14,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import com.google.common.primitives.Longs;
 import com.metabroadcast.common.queue.MessageSender;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -38,7 +40,7 @@ public class MessageQueueingContentWriterTest {
         
         ArgumentCaptor<EntityUpdatedMessage> creatorCaptor = ArgumentCaptor.forClass(EntityUpdatedMessage.class);
         
-        verify(sender).sendMessage(creatorCaptor.capture());
+        verify(sender).sendMessage(creatorCaptor.capture(), eq(Longs.toByteArray(1225L)));
         
         EntityUpdatedMessage message = creatorCaptor.getValue();
         

--- a/src/test/java/org/atlasapi/persistence/content/schedule/mongo/MongoScheduleStoreTest.java
+++ b/src/test/java/org/atlasapi/persistence/content/schedule/mongo/MongoScheduleStoreTest.java
@@ -165,7 +165,14 @@ public class MongoScheduleStoreTest {
         @Override
         public void sendMessage(ScheduleUpdateMessage message) throws MessagingException {
             
-        }};
+        }
+
+        @Override
+        public void sendMessage(ScheduleUpdateMessage scheduleUpdateMessage, byte[] bytes)
+                throws MessagingException {
+
+        }
+    };
     
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/org/atlasapi/persistence/event/MessageQueueingEventWriterTest.java
+++ b/src/test/java/org/atlasapi/persistence/event/MessageQueueingEventWriterTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,6 +21,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import com.google.common.primitives.Longs;
 import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
 import com.metabroadcast.common.queue.MessageSender;
 import com.metabroadcast.common.time.Timestamp;
@@ -62,7 +64,7 @@ public class MessageQueueingEventWriterTest {
 
         messageQueueingEventWriter.createOrUpdate(event);
 
-        verify(sender).sendMessage(messageCaptor.capture());
+        verify(sender).sendMessage(messageCaptor.capture(), eq(Longs.toByteArray(id)));
 
         EntityUpdatedMessage message = messageCaptor.getValue();
         assertThat(message.getEntityId(), is(entityId));


### PR DESCRIPTION
- This is to ensure ordering guarantees for messages by controlling
which partition they are put on