### PR TITLE
Hotfix: Don't process the same LookupRef twice

### DIFF
--- a/src/main/java/org/atlasapi/persistence/lookup/TransitiveLookupWriter.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/TransitiveLookupWriter.java
@@ -250,11 +250,15 @@ public class TransitiveLookupWriter implements LookupWriter {
             
             Queue<LookupRef> direct = Lists.newLinkedList(neighbours(entry));
             //Traverse equivalence graph breadth-first
+            Set<LookupRef> seen = Sets.newHashSet();
             while(!direct.isEmpty()) {
                 LookupRef current = direct.poll();
-                transitiveSet.add(current);
-                LookupEntry currentEntry = checkNotNull(entries.get(current.uri()), "No lookup entry for %s", current);
-                Iterables.addAll(direct, Iterables.filter(neighbours(currentEntry), not(in(transitiveSet))));
+                if (!seen.contains(current)) {
+                    transitiveSet.add(current);
+                    LookupEntry currentEntry = checkNotNull(entries.get(current.uri()), "No lookup entry for %s", current);
+                    Iterables.addAll(direct, Iterables.filter(neighbours(currentEntry), not(in(transitiveSet))));
+                    seen.add(current);
+                }
             }
             
             // Because all entries in the same transitive set should have


### PR DESCRIPTION
We're seeing a seemingly non-terminating while loop when computing
equivalences for YouView +8 day schedule, apparently caused by item
http://youview.com/programmecrid/20160126/fp.bbc.co.uk/SQCMY

We'll keep track of the LookupRefs we've processed, to ensure we
don't process them again.