### PR TITLE
Extract content ID generation logic to LookupBackedContentIdGenerator

### DIFF
--- a/src/main/java/org/atlasapi/persistence/ContentPersistenceModule.java
+++ b/src/main/java/org/atlasapi/persistence/ContentPersistenceModule.java
@@ -8,6 +8,7 @@ import org.atlasapi.persistence.content.ContentGroupResolver;
 import org.atlasapi.persistence.content.ContentGroupWriter;
 import org.atlasapi.persistence.content.ContentResolver;
 import org.atlasapi.persistence.content.ContentWriter;
+import org.atlasapi.persistence.content.LookupBackedContentIdGenerator;
 import org.atlasapi.persistence.content.PeopleQueryResolver;
 import org.atlasapi.persistence.content.people.ItemsPeopleWriter;
 import org.atlasapi.persistence.shorturls.ShortUrlSaver;
@@ -23,6 +24,8 @@ public interface ContentPersistenceModule {
     ContentGroupResolver contentGroupResolver();
     
 	ContentWriter contentWriter();
+
+	ContentWriter nonIdSettingContentWriter();
 	
 	ItemsPeopleWriter itemsPeopleWriter();
 	
@@ -45,4 +48,6 @@ public interface ContentPersistenceModule {
 	PeopleQueryResolver peopleQueryResolver();
 
 	IdGenerator contentIdGenerator();
+
+	LookupBackedContentIdGenerator lookupBackedContentIdGenerator();
 }

--- a/src/main/java/org/atlasapi/persistence/content/IdSettingContentWriter.java
+++ b/src/main/java/org/atlasapi/persistence/content/IdSettingContentWriter.java
@@ -3,23 +3,18 @@ package org.atlasapi.persistence.content;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Item;
-import org.atlasapi.persistence.lookup.entry.LookupEntry;
-import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.metabroadcast.common.ids.IdGenerator;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class IdSettingContentWriter implements ContentWriter {
 
-    private final LookupEntryStore lookupStore;
     private final ContentWriter delegate;
-    private final IdGenerator generator;
+    private final LookupBackedContentIdGenerator lookupBackedContentIdGenerator;
 
-    public IdSettingContentWriter(LookupEntryStore lookupStore, IdGenerator generator, ContentWriter delegate) {
-        this.lookupStore = lookupStore;
-        this.delegate = delegate;
-        this.generator = generator;
+    public IdSettingContentWriter(ContentWriter delegate,
+            LookupBackedContentIdGenerator lookupBackedContentIdGenerator) {
+        this.delegate = checkNotNull(delegate);
+        this.lookupBackedContentIdGenerator = checkNotNull(lookupBackedContentIdGenerator);
     }
     
     @Override
@@ -27,17 +22,8 @@ public class IdSettingContentWriter implements ContentWriter {
         return delegate.createOrUpdate(ensureId(item));
     }
     
-    //Check for existence of a lookup entry for the content. If none, generate a new ID for the content.
     private <T extends Content> T ensureId(T content) {
-        Iterable<LookupEntry> entries = lookupStore.entriesForCanonicalUris(ImmutableList.of(content.getCanonicalUri()));
-
-        if (Iterables.isEmpty(entries)) {
-            content.setId(generator.generateRaw());
-        } else { //ensures an adapter can't override and assign a new id for the content.
-            LookupEntry entry = Iterables.getOnlyElement(entries);
-            content.setId(entry.id());
-        }
-        
+        content.setId(lookupBackedContentIdGenerator.getId(content));
         return content;
     }
 
@@ -45,5 +31,4 @@ public class IdSettingContentWriter implements ContentWriter {
     public void createOrUpdate(Container container) {
         delegate.createOrUpdate(ensureId(container));
     }
-
 }

--- a/src/main/java/org/atlasapi/persistence/content/LookupBackedContentIdGenerator.java
+++ b/src/main/java/org/atlasapi/persistence/content/LookupBackedContentIdGenerator.java
@@ -1,0 +1,35 @@
+package org.atlasapi.persistence.content;
+
+import org.atlasapi.media.entity.Content;
+import org.atlasapi.persistence.lookup.entry.LookupEntry;
+import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
+
+import com.metabroadcast.common.ids.IdGenerator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class LookupBackedContentIdGenerator {
+
+    private final LookupEntryStore lookupStore;
+    private final IdGenerator idGenerator;
+
+    public LookupBackedContentIdGenerator(LookupEntryStore lookupStore, IdGenerator idGenerator) {
+        this.lookupStore = checkNotNull(lookupStore);
+        this.idGenerator = checkNotNull(idGenerator);
+    }
+
+    public <T extends Content> Long getId(T content) {
+        Iterable<LookupEntry> entries = lookupStore
+                .entriesForCanonicalUris(ImmutableList.of(content.getCanonicalUri()));
+
+        if (Iterables.isEmpty(entries)) {
+            return idGenerator.generateRaw();
+        } else {
+            //ensures an adapter can't override and assign a new id for the content.
+            return Iterables.getOnlyElement(entries).id();
+        }
+    }
+}

--- a/src/test/java/org/atlasapi/persistence/content/IdSettingContentWriterTest.java
+++ b/src/test/java/org/atlasapi/persistence/content/IdSettingContentWriterTest.java
@@ -1,12 +1,14 @@
 package org.atlasapi.persistence.content;
 
-import static org.hamcrest.Matchers.hasItems;
-
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.persistence.lookup.entry.LookupEntry;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
+
+import com.metabroadcast.common.ids.IdGenerator;
+
+import com.google.common.collect.ImmutableList;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.jmock.Expectations;
@@ -16,8 +18,7 @@ import org.junit.Test;
 import org.junit.internal.matchers.TypeSafeMatcher;
 import org.junit.runner.RunWith;
 
-import com.google.common.collect.ImmutableList;
-import com.metabroadcast.common.ids.IdGenerator;
+import static org.hamcrest.Matchers.hasItems;
 
 @RunWith(JMock.class)
 public class IdSettingContentWriterTest {
@@ -26,8 +27,12 @@ public class IdSettingContentWriterTest {
     private final LookupEntryStore lookupStore = context.mock(LookupEntryStore.class);
     private final ContentWriter delegate = context.mock(ContentWriter.class);
     private final IdGenerator idGenerator = context.mock(IdGenerator.class);
+    private final LookupBackedContentIdGenerator lookupBackedContentIdGenerator =
+            new LookupBackedContentIdGenerator(lookupStore, idGenerator);
     
-    private final IdSettingContentWriter writer = new IdSettingContentWriter(lookupStore, idGenerator, delegate);
+    private final IdSettingContentWriter writer = new IdSettingContentWriter(
+            delegate, lookupBackedContentIdGenerator
+    );
     
     @Test
     public void testCreatingItemGeneratesNewId() {


### PR DESCRIPTION
- This is to allow the ContentWriteController in the app server to
generate the ID immediately when it receives the POST/PUT request and
return that ID to the caller while delegating the actual writing of
the content to a queue worker
- Cleanup ConstructorBasedMongoContentPersistenceModule and
MongoContentPersistenceModule by adding @Override annotations and
passing booleans where appropriate instead of strings of booleans
- Remove ids.generate feature switch. This is dangerous as the system
will not behave correctly if someone accidentally sets this to false
in production