### PR TITLE
Only hydrate broadcasts when needed

### DIFF
--- a/src/main/java/org/atlasapi/persistence/content/DefaultEquivalentContentResolver.java
+++ b/src/main/java/org/atlasapi/persistence/content/DefaultEquivalentContentResolver.java
@@ -41,19 +41,25 @@ public class DefaultEquivalentContentResolver implements EquivalentContentResolv
     }
     
     @Override
-    public EquivalentContent resolveUris(Iterable<String> uris, ApplicationConfiguration appConfig, Set<Annotation> activeAnnotations, boolean withAliases) {
+    public EquivalentContent resolveUris(Iterable<String> uris, ApplicationConfiguration appConfig,
+            Set<Annotation> activeAnnotations, boolean withAliases) {
+
         Iterable<LookupEntry> entries = lookupResolver.entriesForIdentifiers(uris, withAliases);
-        return filterAndResolveEntries(ImmutableSet.copyOf(entries), uris, appConfig);
+        return filterAndResolveEntries(ImmutableSet.copyOf(entries), uris, appConfig, activeAnnotations);
     }
     
     @Override
-    public EquivalentContent resolveIds(Iterable<Long> ids, ApplicationConfiguration appConfig, Set<Annotation> activeAnnotations) {
+    public EquivalentContent resolveIds(Iterable<Long> ids, ApplicationConfiguration appConfig,
+            Set<Annotation> activeAnnotations) {
+
         Iterable<LookupEntry> entries = lookupResolver.entriesForIds(ids);
         Set<String> uris = Sets.newHashSet();
         for (LookupEntry entry : entries) {
             uris.add(entry.uri());
         }
-        return filterAndResolveEntries(ImmutableSet.copyOf(entries), uris, appConfig);
+        return filterAndResolveEntries(
+                ImmutableSet.copyOf(entries), uris, appConfig,
+                activeAnnotations);
     }
     
     @Override
@@ -64,10 +70,14 @@ public class DefaultEquivalentContentResolver implements EquivalentContentResolv
         for (LookupEntry entry : entries) {
             uris.add(entry.uri());
         }
-        return filterAndResolveEntries(ImmutableSet.copyOf(entries), uris, appConfig); 
+        return filterAndResolveEntries(ImmutableSet.copyOf(entries), uris, appConfig,
+                activeAnnotations
+        );
     }
 
-    protected EquivalentContent filterAndResolveEntries(Set<LookupEntry> entries, Iterable<String> uris, ApplicationConfiguration appConfig) {
+    protected EquivalentContent filterAndResolveEntries(Set<LookupEntry> entries,
+            Iterable<String> uris, ApplicationConfiguration appConfig,
+            Set<Annotation> activeAnnotations) {
         if (Iterables.isEmpty(entries)) {
             return EquivalentContent.empty();
         }

--- a/src/main/java/org/atlasapi/persistence/content/DummyKnownTypeContentResolver.java
+++ b/src/main/java/org/atlasapi/persistence/content/DummyKnownTypeContentResolver.java
@@ -1,9 +1,11 @@
 package org.atlasapi.persistence.content;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.LookupRef;
+import org.atlasapi.output.Annotation;
 import org.atlasapi.persistence.content.ResolvedContent.ResolvedContentBuilder;
 
 import com.google.common.collect.Maps;
@@ -22,7 +24,13 @@ public class DummyKnownTypeContentResolver implements KnownTypeContentResolver {
         
         return results.build();
     }
-    
+
+    @Override
+    public ResolvedContent findByLookupRefs(Iterable<LookupRef> lookupRefs,
+            Set<Annotation> activeAnnotations) {
+        return findByLookupRefs(lookupRefs);
+    }
+
     public DummyKnownTypeContentResolver respondTo(Iterable<? extends Identified> content) {
         for (Identified item : content) {
             this.content.put(item.getCanonicalUri(), item);

--- a/src/main/java/org/atlasapi/persistence/content/FilterScheduleOnlyKnownTypeContentResolver.java
+++ b/src/main/java/org/atlasapi/persistence/content/FilterScheduleOnlyKnownTypeContentResolver.java
@@ -1,6 +1,9 @@
 package org.atlasapi.persistence.content;
 
+import java.util.Set;
+
 import org.atlasapi.media.entity.LookupRef;
+import org.atlasapi.output.Annotation;
 
 public class FilterScheduleOnlyKnownTypeContentResolver implements KnownTypeContentResolver {
     
@@ -13,6 +16,13 @@ public class FilterScheduleOnlyKnownTypeContentResolver implements KnownTypeCont
     @Override
     public ResolvedContent findByLookupRefs(Iterable<LookupRef> lookupRefs) {
         ResolvedContent resolvedContent = resolver.findByLookupRefs(lookupRefs);
+        return resolvedContent.filterContent(FilterScheduleOnlyContentResolver.NOT_SCHEDULE_ONLY);
+    }
+
+    @Override
+    public ResolvedContent findByLookupRefs(Iterable<LookupRef> lookupRefs,
+            Set<Annotation> activeAnnotations) {
+        ResolvedContent resolvedContent = resolver.findByLookupRefs(lookupRefs, activeAnnotations);
         return resolvedContent.filterContent(FilterScheduleOnlyContentResolver.NOT_SCHEDULE_ONLY);
     }
 }

--- a/src/main/java/org/atlasapi/persistence/content/KnownTypeContentResolver.java
+++ b/src/main/java/org/atlasapi/persistence/content/KnownTypeContentResolver.java
@@ -1,6 +1,9 @@
 package org.atlasapi.persistence.content;
 
+import java.util.Set;
+
 import org.atlasapi.media.entity.LookupRef;
+import org.atlasapi.output.Annotation;
 
 /**
  * Retrieve content from a known internal content table
@@ -10,5 +13,6 @@ import org.atlasapi.media.entity.LookupRef;
 public interface KnownTypeContentResolver {
 
     ResolvedContent findByLookupRefs(Iterable<LookupRef> lookupRefs);
+    ResolvedContent findByLookupRefs(Iterable<LookupRef> lookupRefs, Set<Annotation> activeAnnotations);
     
 }

--- a/src/main/java/org/atlasapi/persistence/content/cassandra/CassandraKnownTypeContentResolver.java
+++ b/src/main/java/org/atlasapi/persistence/content/cassandra/CassandraKnownTypeContentResolver.java
@@ -1,6 +1,9 @@
 package org.atlasapi.persistence.content.cassandra;
 
+import java.util.Set;
+
 import org.atlasapi.media.entity.LookupRef;
+import org.atlasapi.output.Annotation;
 import org.atlasapi.persistence.content.KnownTypeContentResolver;
 import org.atlasapi.persistence.content.ResolvedContent;
 
@@ -19,5 +22,11 @@ public class CassandraKnownTypeContentResolver implements KnownTypeContentResolv
     @Override
     public ResolvedContent findByLookupRefs(Iterable<LookupRef> lookupRefs) {
         return store.findByCanonicalUris(Iterables.transform(lookupRefs, LookupRef.TO_URI));
+    }
+
+    @Override
+    public ResolvedContent findByLookupRefs(Iterable<LookupRef> lookupRefs,
+            Set<Annotation> activeAnnotations) {
+        return findByLookupRefs(lookupRefs);
     }
 }

--- a/src/main/java/org/atlasapi/persistence/content/mongo/MongoContentLister.java
+++ b/src/main/java/org/atlasapi/persistence/content/mongo/MongoContentLister.java
@@ -197,7 +197,7 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
     private final Function<DBObject, Item> TO_ITEM = new Function<DBObject, Item>() {
         @Override
         public Item apply(DBObject input) {
-            return itemTranslator.fromDBObject(input, null);
+            return itemTranslator.fromDBObject(input, null, true);
         }
     };
 

--- a/src/main/java/org/atlasapi/persistence/content/mongo/MongoContentResolver.java
+++ b/src/main/java/org/atlasapi/persistence/content/mongo/MongoContentResolver.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.atlasapi.media.entity.EntityType;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.LookupRef;
+import org.atlasapi.output.Annotation;
 import org.atlasapi.persistence.content.KnownTypeContentResolver;
 import org.atlasapi.persistence.content.ResolvedContent;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
@@ -48,7 +49,11 @@ public class MongoContentResolver implements KnownTypeContentResolver {
         this.lookupEntryStore = checkNotNull(lookupEntryStore);
     }
 
-    public ResolvedContent findByLookupRefs(Iterable<LookupRef> lookupRefs) {
+    @Override
+    public ResolvedContent findByLookupRefs(Iterable<LookupRef> lookupRefs, Set<Annotation> activeAnnotations) {
+        boolean hydrateBroadcasts = activeAnnotations == null
+                || activeAnnotations.contains(Annotation.BROADCASTS);
+
         Builder<String, Identified> results = ImmutableMap.builder();
         Set<String> foundUris = Sets.newHashSet();
         Multimap<DBCollection, String> idsGroupedByTable = HashMultimap.create();
@@ -61,7 +66,7 @@ public class MongoContentResolver implements KnownTypeContentResolver {
             DBCursor found = lookupInOneTable.getKey().find(where().idIn(lookupInOneTable.getValue()).build());
             if (found != null) {
                 for (DBObject dbo : found) {
-                    Identified model = toModel(dbo);
+                    Identified model = toModel(dbo, hydrateBroadcasts);
                     if (!foundUris.contains(model.getCanonicalUri())) {
                         results.put(model.getCanonicalUri(), model);
                         foundUris.add(model.getCanonicalUri());
@@ -76,6 +81,11 @@ public class MongoContentResolver implements KnownTypeContentResolver {
         return ResolvedContent.builder().putAll(res).build();
     }
 
+    @Override
+    public ResolvedContent findByLookupRefs(Iterable<LookupRef> lookupRefs) {
+        return findByLookupRefs(null);
+    }
+
     private void addIdsToResults(ImmutableMap<String, Identified> uriToIdentified) {
         Map<String, Long> idsForCanonicalUris = lookupEntryStore.idsForCanonicalUris(uriToIdentified.keySet());
         
@@ -88,7 +98,7 @@ public class MongoContentResolver implements KnownTypeContentResolver {
         }
     }
 
-    private Identified toModel(DBObject dbo) {
+    private Identified toModel(DBObject dbo, boolean hydrateBroadcasts) {
         if(dbo == null) {
             return null;
         }
@@ -107,7 +117,7 @@ public class MongoContentResolver implements KnownTypeContentResolver {
         	case CLIP:
         	case FILM:
         	case SONG:
-        		return itemTranslator.fromDBObject(dbo, null);
+        		return itemTranslator.fromDBObject(dbo, null, hydrateBroadcasts);
         }
         throw new IllegalArgumentException("Unknown type: " + type);
     }

--- a/src/main/java/org/atlasapi/persistence/content/schedule/mongo/MongoScheduleStore.java
+++ b/src/main/java/org/atlasapi/persistence/content/schedule/mongo/MongoScheduleStore.java
@@ -77,6 +77,8 @@ import com.mongodb.DBCollection;
 public class MongoScheduleStore implements ScheduleResolver, ScheduleWriter {
 
 	private final static Duration MAX_DURATION = Duration.standardDays(14);
+    private final static Set<Annotation> DEFAULT_ANNOTATIONS_WITHOUT_BROADCASTS
+            = Sets.difference(Annotation.defaultAnnotations(), ImmutableSet.of(Annotation.BROADCASTS));
 
 	private final ScheduleEntryBuilder scheduleEntryBuilder;
     private final DBCollection collection;
@@ -377,7 +379,8 @@ public class MongoScheduleStore implements ScheduleResolver, ScheduleWriter {
     private Map<String, Maybe<Identified>> findAndMerge(ApplicationConfiguration mergeConfig,
             Iterable<Entry<Channel, ItemRefAndBroadcast>> refs) {
         ImmutableSet<String> uris = uniqueUris(refs);
-        EquivalentContent resolved = equivalentContentResolver.resolveUris(uris, mergeConfig, Annotation.defaultAnnotations(), false);
+        EquivalentContent resolved = equivalentContentResolver.resolveUris(uris, mergeConfig,
+                DEFAULT_ANNOTATIONS_WITHOUT_BROADCASTS, false);
         ImmutableMap.Builder<String, Maybe<Identified>> result = ImmutableMap.builder();
         for (String uri : uris) {
             Set<Content> equivalents = resolved.get(uri);

--- a/src/main/java/org/atlasapi/persistence/media/entity/ClipTranslator.java
+++ b/src/main/java/org/atlasapi/persistence/media/entity/ClipTranslator.java
@@ -19,7 +19,7 @@ public class ClipTranslator implements ModelTranslator<Clip> {
         if (clip == null) {
             clip = new Clip();
         }
-        itemTranslator.fromDBObject(dbObject, clip);
+        itemTranslator.fromDBObject(dbObject, clip, true);
         clip.setClipOf((String) dbObject.get("clipOfUri"));
         return clip;
     }

--- a/src/main/java/org/atlasapi/persistence/media/entity/ContainerTranslator.java
+++ b/src/main/java/org/atlasapi/persistence/media/entity/ContainerTranslator.java
@@ -92,7 +92,7 @@ public class ContainerTranslator {
         if (entity == null) {
             entity = (Container) DescribedTranslator.newModel(dbObject);
         }
-        contentTranslator.fromDBObject(dbObject, entity);
+        contentTranslator.fromDBObject(dbObject, entity, true);
 
         Iterable<ChildRef> childRefs;
         if (dbObject.containsField(CHILDREN_KEY)) {

--- a/src/main/java/org/atlasapi/persistence/media/entity/ContentTranslator.java
+++ b/src/main/java/org/atlasapi/persistence/media/entity/ContentTranslator.java
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class ContentTranslator implements ModelTranslator<Content> {
+public class ContentTranslator {
 
     public static final String PEOPLE = "people";
     public static String CLIPS_KEY = "clips";
@@ -77,8 +77,7 @@ public class ContentTranslator implements ModelTranslator<Content> {
 
     }
 
-    @Override
-    public Content fromDBObject(DBObject dbObject, Content entity) {
+    public Content fromDBObject(DBObject dbObject, Content entity, boolean hydrateBroadcasts) {
         describedTranslator.fromDBObject(dbObject, entity);
 
         decodeClips(dbObject, entity);
@@ -110,7 +109,7 @@ public class ContentTranslator implements ModelTranslator<Content> {
                 if (versionDbo == null) {
                     throw new IllegalStateException("Cannot read item stored with null version: " + entity.getCanonicalUri());
                 }
-                Version version = versionTranslator.fromDBObject(versionDbo, null);
+                Version version = versionTranslator.fromDBObject(versionDbo, null, hydrateBroadcasts);
                 versions.add(version);
             }
             entity.setVersions(versions);
@@ -203,7 +202,6 @@ public class ContentTranslator implements ModelTranslator<Content> {
 
     }
 
-    @Override
     public DBObject toDBObject(DBObject dbObject, Content entity) {
         dbObject = describedTranslator.toDBObject(dbObject, entity);
         encodeClips(dbObject, entity);

--- a/src/main/java/org/atlasapi/persistence/media/entity/ItemTranslator.java
+++ b/src/main/java/org/atlasapi/persistence/media/entity/ItemTranslator.java
@@ -1,6 +1,5 @@
 package org.atlasapi.persistence.media.entity;
 
-import java.util.List;
 import java.util.Set;
 
 import org.atlasapi.media.entity.EntityType;
@@ -12,28 +11,24 @@ import org.atlasapi.media.entity.ReleaseDate;
 import org.atlasapi.media.entity.ReleaseDate.ReleaseType;
 import org.atlasapi.media.entity.Song;
 import org.atlasapi.media.entity.Subtitles;
-import org.atlasapi.media.entity.Version;
-import org.atlasapi.persistence.ModelTranslator;
 import org.atlasapi.persistence.content.mongo.DbObjectHashCodeDebugger;
+
+import com.metabroadcast.common.ids.NumberToShortStringCodec;
+import com.metabroadcast.common.intl.Countries;
+import com.metabroadcast.common.intl.Country;
+import com.metabroadcast.common.persistence.translator.TranslatorUtils;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
 import org.joda.time.Duration;
 import org.joda.time.LocalDate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
-import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Ordering;
-import com.google.common.collect.Sets;
-import com.metabroadcast.common.ids.NumberToShortStringCodec;
-import com.metabroadcast.common.intl.Countries;
-import com.metabroadcast.common.intl.Country;
-import com.metabroadcast.common.persistence.translator.TranslatorUtils;
-import com.mongodb.BasicDBList;
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
-
-public class ItemTranslator implements ModelTranslator<Item> {
+public class ItemTranslator {
     
 
     private static final Logger log = LoggerFactory.getLogger(ItemTranslator.class);
@@ -88,17 +83,16 @@ public class ItemTranslator implements ModelTranslator<Item> {
     }
     
     public Item fromDB(DBObject dbObject) {
-        return fromDBObject(dbObject, null);
+        return fromDBObject(dbObject, null, true);
     }
-    
-    @Override
-    public Item fromDBObject(DBObject dbObject, Item item) {
+
+    public Item fromDBObject(DBObject dbObject, Item item, boolean hydrateBroadcasts) {
 
         if (item == null) {
             item = (Item) DescribedTranslator.newModel(dbObject);
         }
         
-        contentTranslator.fromDBObject(dbObject, item);
+        contentTranslator.fromDBObject(dbObject, item, hydrateBroadcasts);
         
         item.setIsLongForm((Boolean) dbObject.get(IS_LONG_FORM_KEY));
         item.setBlackAndWhite(TranslatorUtils.toBoolean(dbObject, BLACK_AND_WHITE_KEY));
@@ -181,7 +175,6 @@ public class ItemTranslator implements ModelTranslator<Item> {
 	    return toDBObject(null, item);
 	}
 
-    @Override
     public DBObject toDBObject(DBObject itemDbo, Item entity) {
         itemDbo = contentTranslator.toDBObject(itemDbo, entity);
         itemDbo.put(TYPE_KEY, EntityType.from(entity).toString());

--- a/src/test/java/org/atlasapi/persistence/media/entity/ContentTranslatorTest.java
+++ b/src/test/java/org/atlasapi/persistence/media/entity/ContentTranslatorTest.java
@@ -26,7 +26,7 @@ public class ContentTranslatorTest {
         List<Event> events = ImmutableList.of(event);
         Content content = createContentWithEvents(events);
         
-        Content translated = translator.fromDBObject(translator.toDBObject(null, content), new Item());
+        Content translated = translator.fromDBObject(translator.toDBObject(null, content), new Item(), true);
         
         EventRef translatedEvent = Iterables.getOnlyElement(translated.events());
         
@@ -39,7 +39,7 @@ public class ContentTranslatorTest {
         List<EventRef> events = ImmutableList.of(event);
         Content content = createContentWithEventRefs(events);
         
-        Content translated = translator.fromDBObject(translator.toDBObject(null, content), new Item());
+        Content translated = translator.fromDBObject(translator.toDBObject(null, content), new Item(), true);
         
         EventRef translatedEvent = Iterables.getOnlyElement(translated.events());
         

--- a/src/test/java/org/atlasapi/persistence/media/entity/ItemTranslatorTest.java
+++ b/src/test/java/org/atlasapi/persistence/media/entity/ItemTranslatorTest.java
@@ -166,7 +166,7 @@ public class ItemTranslatorTest extends TestCase {
         DBObject dbObject = itemTranslator.toDBObject(null, item);
         
         collection.save(dbObject);
-        Item i = itemTranslator.fromDBObject(collection.findOne(new MongoQueryBuilder().idEquals(item.getCanonicalUri()).build()), null);
+        Item i = itemTranslator.fromDBObject(collection.findOne(new MongoQueryBuilder().idEquals(item.getCanonicalUri()).build()), null, true);
 
         assertEquals(i.getCanonicalUri(), item.getCanonicalUri());
         assertEquals(i.getCurie(), item.getCurie());
@@ -278,7 +278,7 @@ public class ItemTranslatorTest extends TestCase {
         DBObject dbObject = itemTranslator.toDBObject(null, item);
 
         collection.save(dbObject);
-        Item i = itemTranslator.fromDBObject(collection.findOne(new MongoQueryBuilder().idEquals(item.getCanonicalUri()).build()), null);
+        Item i = itemTranslator.fromDBObject(collection.findOne(new MongoQueryBuilder().idEquals(item.getCanonicalUri()).build()), null, true);
 
         assertEquals(item.getShortDescription(), i.getShortDescription());
         assertEquals(item.getMediumDescription(), i.getMediumDescription());

--- a/src/test/java/org/atlasapi/persistence/media/entity/VersionTranslatorTest.java
+++ b/src/test/java/org/atlasapi/persistence/media/entity/VersionTranslatorTest.java
@@ -54,7 +54,7 @@ public class VersionTranslatorTest extends TestCase {
         
         DBObject dbObject = vt.toDBObject(null, version);
         
-        Version v = vt.fromDBObject(dbObject, null);
+        Version v = vt.fromDBObject(dbObject, null, true);
         assertEquals(version.getDuration(), v.getDuration());
         assertEquals(version.getPublishedDuration(), v.getPublishedDuration());
         assertEquals(version.getProvider(), v.getProvider());


### PR DESCRIPTION
When resolving schedule requests there is no need to
convert all broadcasts, only to then throw them away. We're
seeing some performance blips which could be related to the
number of broadcasts on some schedule items, so this is an
attempt to reduce load in these cases.