### PR TITLE
Upgrade to Spring 4.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jms</artifactId>
-            <version>3.0.5.RELEASE</version>
+            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>com.metabroadcast.common.queue</groupId>
@@ -186,7 +186,7 @@
     <properties>
         <atlas.version>${project.version}</atlas.version>
         <common.version>1.0-SNAPSHOT</common.version>
-        <spring.version>3.0.5.RELEASE</spring.version>
+        <spring.version>4.0.9.RELEASE</spring.version>
         <amq.version>5.9.0</amq.version>
         <jacoco.version>0.7.5.201505241946</jacoco.version>
         <guava.version>18.0</guava.version>


### PR DESCRIPTION
- The intention is to get a version of Spring/ASM that supports Java
  8 while making the minimum number of code changes
- Spring 4.2.x was avoided because it removes some deprecated APIs we
  are using
- Spring 4.1.x was avoided because it mandates use of Jackson 2