### PR TITLE
Changing map of publisher-equivalence to multimap

### DIFF
--- a/src/main/java/org/atlasapi/equiv/CassandraEquivalenceSummaryStore.java
+++ b/src/main/java/org/atlasapi/equiv/CassandraEquivalenceSummaryStore.java
@@ -3,8 +3,10 @@ package org.atlasapi.equiv;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -12,9 +14,12 @@ import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.persistence.cassandra.CassandraPersistenceException;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializationContext;
@@ -28,6 +33,7 @@ import com.google.gson.JsonSerializer;
 import com.google.gson.reflect.TypeToken;
 import com.metabroadcast.common.collect.ImmutableOptionalMap;
 import com.metabroadcast.common.collect.OptionalMap;
+
 import com.netflix.astyanax.AstyanaxContext;
 import com.netflix.astyanax.ColumnListMutation;
 import com.netflix.astyanax.Keyspace;
@@ -62,8 +68,7 @@ public class CassandraEquivalenceSummaryStore implements EquivalenceSummaryStore
     private static final class EquivalenceSummaryDeserializer implements
             JsonDeserializer<EquivalenceSummary> {
 
-        private static final TypeToken<Map<Publisher,ContentRef>> equivsTypeToken
-            = new TypeToken<Map<Publisher,ContentRef>>(){};
+        private static final TypeToken<PersistentEquivalencesContentRefs> equivalentContentRefsTypeToken = new TypeToken<PersistentEquivalencesContentRefs>(){};
         private static final TypeToken<List<String>> candidatesTypeToken
             = new TypeToken<List<String>>(){};
 
@@ -74,7 +79,7 @@ public class CassandraEquivalenceSummaryStore implements EquivalenceSummaryStore
             String subject = obj.get("subject").getAsString();
             String parent = deserializeParent(obj.get("parent"));
             List<String> candidates = deserializeCandidates(context, obj.get("candidates"));
-            Map<Publisher,ContentRef> equivalents = deserializeEquivalents(context, obj.get("equivalents"));
+            Multimap<Publisher,ContentRef> equivalents = deserializeEquivalents(context, obj.get("equivalents"));
             return new EquivalenceSummary(subject, parent, candidates, equivalents);
         }
 
@@ -82,15 +87,37 @@ public class CassandraEquivalenceSummaryStore implements EquivalenceSummaryStore
             return parent == null ? null : parent.getAsString();
         }
 
-        private Map<Publisher, ContentRef> deserializeEquivalents(
+        private Multimap<Publisher, ContentRef> deserializeEquivalents(
                 JsonDeserializationContext context, JsonElement equivs) {
-            return context.deserialize(equivs, equivsTypeToken.getType());
+            JsonObject jsonObject = (JsonObject) equivs;
+            ImmutableMultimap.Builder<Publisher, ContentRef> builder = ImmutableMultimap.builder();
+            Set<Map.Entry<String, JsonElement>> entries = jsonObject.entrySet();
+            for (Map.Entry<String, JsonElement> entry : entries) {
+                PersistentEquivalencesContentRefs contentRefWithEquivs = deserializeContentRef(context, entry.getValue());
+                Publisher publisher = Publisher.fromKey(entry.getKey()).requireValue();
+                if(contentRefWithEquivs.getEquivalents() != null) {
+                    for (ContentRef ref : contentRefWithEquivs.getEquivalents()) {
+                        builder.put(publisher, ref);
+                    }
+                } else {
+                    ContentRef contentRef = new ContentRef(contentRefWithEquivs.getCanonicalUri(), contentRefWithEquivs.getPublisher(), contentRefWithEquivs.getParentUri());
+                    builder.put(publisher,contentRef);
+                }
+            }
+            return builder.build();
+        }
+
+        private PersistentEquivalencesContentRefs deserializeContentRef(JsonDeserializationContext context,
+                JsonElement contentRef) {
+            return context.deserialize(contentRef, equivalentContentRefsTypeToken.getType());
         }
 
         private List<String> deserializeCandidates(JsonDeserializationContext context,
                 JsonElement candidates) {
             return context.deserialize(candidates, candidatesTypeToken.getType());
         }
+
+
     }
 
     private static final String SUMMARY_CF_NAME = "EquivalenceSummaries";
@@ -135,7 +162,32 @@ public class CassandraEquivalenceSummaryStore implements EquivalenceSummaryStore
     }
 
     private byte[] serialize(EquivalenceSummary summary) throws Exception {
-        return gson.toJson(summary).getBytes();
+        ImmutableMultimap<Publisher, ContentRef> equivalents = summary.getEquivalents();
+        ContentRef firstContentRef = equivalents.values().stream().findFirst().get();
+        ImmutableMap.Builder<Publisher, PersistentEquivalencesContentRefs> builder = ImmutableMap.builder();
+        for (Map.Entry<Publisher, Collection<ContentRef>> entry : equivalents.asMap()
+                .entrySet()) {
+            PersistentEquivalencesContentRefs contentRefs = getEquivalentContentRefs(firstContentRef, entry);
+            builder.put(entry.getKey(), contentRefs);
+        }
+        PersistenceEquivalenceSummary summaryWithMultimap =
+                new PersistenceEquivalenceSummary.Builder()
+                        .withSubject(summary.getSubject())
+                        .withParent(summary.getParent())
+                        .withCandidates(summary.getCandidates())
+                        .withEquivalents(builder.build()).build();
+
+        return gson.toJson(summaryWithMultimap).getBytes();
+    }
+
+    private PersistentEquivalencesContentRefs getEquivalentContentRefs(
+            ContentRef firstContentRef, Map.Entry<Publisher, Collection<ContentRef>> entry) {
+        return PersistentEquivalencesContentRefs.builder()
+                .withSubject(firstContentRef.getCanonicalUri())
+                .withParentUri(firstContentRef.getParentUri())
+                .withPublisher(firstContentRef.getPublisher())
+                .withEquivalents(ImmutableList.copyOf(entry.getValue()))
+                .build();
     }
 
     @Override
@@ -179,5 +231,149 @@ public class CassandraEquivalenceSummaryStore implements EquivalenceSummaryStore
             throw new CassandraPersistenceException(row.getKey(), e);
         }
     }
+
+    private static class PersistenceEquivalenceSummary {
+        private final String subject;
+        private final String parent;
+        private final ImmutableList<String> candidates;
+        private final ImmutableMap<Publisher, PersistentEquivalencesContentRefs> equivalents;
+
+        private PersistenceEquivalenceSummary(String subject, String parent,
+                ImmutableList<String> candidates,
+                ImmutableMap<Publisher, PersistentEquivalencesContentRefs> equivalents) {
+            this.subject = subject;
+            this.parent = parent;
+            this.candidates = candidates;
+            this.equivalents = equivalents;
+        }
+
+        public String getSubject() {
+            return subject;
+        }
+
+        public String getParent() {
+            return parent;
+        }
+
+        public ImmutableList<String> getCandidates() {
+            return candidates;
+        }
+
+        public ImmutableMap<Publisher, PersistentEquivalencesContentRefs> getEquivalents() {
+            return equivalents;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static final class Builder {
+
+            private String subject;
+            private String parent;
+            private ImmutableList<String> candidates;
+            private ImmutableMap<Publisher, PersistentEquivalencesContentRefs> equivalents;
+
+            private Builder() {
+            }
+
+            public Builder withSubject(String subject) {
+                this.subject = subject;
+                return this;
+            }
+
+            public Builder withParent(String parent) {
+                this.parent = parent;
+                return this;
+            }
+
+            public Builder withCandidates(ImmutableList<String> candidates) {
+                this.candidates = candidates;
+                return this;
+            }
+
+            public Builder withEquivalents(
+                    ImmutableMap<Publisher, PersistentEquivalencesContentRefs> equivalents) {
+                this.equivalents = equivalents;
+                return this;
+            }
+
+            public PersistenceEquivalenceSummary build() {
+                return new PersistenceEquivalenceSummary(subject, parent, candidates, equivalents);
+            }
+        }
+
+    }
+
+    private static class PersistentEquivalencesContentRefs {
+        private final String canonicalUri;
+        private final Publisher publisher;
+        private final String parentUri;
+        private final List<ContentRef> equivalents;
+
+        private PersistentEquivalencesContentRefs(String canonicalUri, Publisher publisher, String parentUri,
+                List<ContentRef> equivalents) {
+            this.canonicalUri = canonicalUri;
+            this.publisher = publisher;
+            this.parentUri = parentUri;
+            this.equivalents = equivalents;
+        }
+
+        public Publisher getPublisher() {
+            return publisher;
+        }
+
+        public String getParentUri() {
+            return parentUri;
+        }
+
+        public List<ContentRef> getEquivalents() {
+            return equivalents;
+        }
+
+        public String getCanonicalUri() {
+            return canonicalUri;
+        }
+
+        public static Builder builder() {
+            return new PersistentEquivalencesContentRefs.Builder();
+        }
+
+        public static final class Builder {
+
+            private String subject;
+            private Publisher publisher;
+            private String parentUri;
+            private List<ContentRef> equivalents;
+
+            private Builder() {
+            }
+
+            public Builder withSubject(String subject) {
+                this.subject = subject;
+                return this;
+            }
+
+            public Builder withParentUri(String parentUri) {
+                this.parentUri = parentUri;
+                return this;
+            }
+
+            public Builder withPublisher(Publisher publisher) {
+                this.publisher = publisher;
+                return this;
+            }
+
+            public Builder withEquivalents(List<ContentRef> equivalents) {
+                this.equivalents = equivalents;
+                return this;
+            }
+
+            public PersistentEquivalencesContentRefs build() {
+                return new PersistentEquivalencesContentRefs(subject, publisher, parentUri, equivalents);
+            }
+        }
+    }
+
 
 }

--- a/src/test/java/org/atlasapi/equiv/CassandraEquivalenceSummaryStoreTest.java
+++ b/src/test/java/org/atlasapi/equiv/CassandraEquivalenceSummaryStoreTest.java
@@ -1,27 +1,31 @@
 package org.atlasapi.equiv;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 import org.atlasapi.media.entity.Publisher;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.metabroadcast.common.collect.OptionalMap;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.netflix.astyanax.AstyanaxContext;
 import com.netflix.astyanax.Keyspace;
 import com.netflix.astyanax.connectionpool.NodeDiscoveryType;
 import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
 import com.netflix.astyanax.connectionpool.exceptions.OperationException;
 import com.netflix.astyanax.connectionpool.impl.ConnectionPoolConfigurationImpl;
+import com.netflix.astyanax.connectionpool.impl.ConnectionPoolType;
 import com.netflix.astyanax.connectionpool.impl.CountingConnectionPoolMonitor;
+import com.netflix.astyanax.cql.CqlStatement;
 import com.netflix.astyanax.impl.AstyanaxConfigurationImpl;
 import com.netflix.astyanax.thrift.ThriftFamilyFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 @Ignore(value="Enable if running a local Cassandra instance with Atlas schema.")
 public class CassandraEquivalenceSummaryStoreTest {
@@ -29,30 +33,39 @@ public class CassandraEquivalenceSummaryStoreTest {
     private CassandraEquivalenceSummaryStore store;
     
     // TODO move these out to an environment property
-    private static final String CASSANDRA_HOST = "127.0.0.1";
-    private static final String CLUSTER = "Build";
+    private static final String CLUSTER_NAME = "Build";
+    private static final String KEYSPACE_NAME = "Atlas";
+    private static final String SEEDS = "localhost";
+    private static final int CLIENT_THREADS = 5;
+    private static final int CONNECTION_TIMEOUT = 1000;
+    private static final int PORT = 9160;
+    private CqlStatement cqlStatement;
 
     private AstyanaxContext<Keyspace> context;
     
     @Before
-    public void setup() {
+    public void setup() throws Exception {
         context = new AstyanaxContext.Builder()
-            .forCluster(CLUSTER)
-            .forKeyspace("Atlas")
-            .withAstyanaxConfiguration(
-                new AstyanaxConfigurationImpl().setDiscoveryType(NodeDiscoveryType.NONE)
-            )
-            .withConnectionPoolConfiguration(
-                new ConnectionPoolConfigurationImpl(CLUSTER)
-                    .setPort(9160)
-                    .setMaxBlockedThreadsPerHost(Runtime.getRuntime().availableProcessors() * 10)
-                    .setMaxConnsPerHost(Runtime.getRuntime().availableProcessors() * 10)
-                    .setConnectTimeout(10000)
-                    .setSeeds(CASSANDRA_HOST)
-            )
-            .withConnectionPoolMonitor(new CountingConnectionPoolMonitor())
-            .buildKeyspace(ThriftFamilyFactory.getInstance());
+                .forCluster(CLUSTER_NAME)
+                .forKeyspace(KEYSPACE_NAME)
+                .withAstyanaxConfiguration(new AstyanaxConfigurationImpl()
+                        .setDiscoveryType(NodeDiscoveryType.RING_DESCRIBE)
+                        .setConnectionPoolType(ConnectionPoolType.ROUND_ROBIN)
+                        .setCqlVersion("3.0.0")
+                        .setTargetCassandraVersion("1.2")
+                )
+                .withConnectionPoolConfiguration(new ConnectionPoolConfigurationImpl("Atlas")
+                        .setPort(PORT)
+                        .setMaxBlockedThreadsPerHost(CLIENT_THREADS)
+                        .setMaxConnsPerHost(CLIENT_THREADS)
+                        .setMaxConns(CLIENT_THREADS * 5)
+                        .setConnectTimeout(CONNECTION_TIMEOUT)
+                        .setSeeds(SEEDS)
+                )
+                .withConnectionPoolMonitor(new CountingConnectionPoolMonitor())
+                .buildKeyspace(ThriftFamilyFactory.getInstance());
         context.start();
+        cqlStatement = context.getClient().prepareCqlStatement();
         store = new CassandraEquivalenceSummaryStore(context, 1000);
     }
     
@@ -60,11 +73,52 @@ public class CassandraEquivalenceSummaryStoreTest {
     public void cleardown() throws OperationException, ConnectionException {
         context.getEntity().truncateColumnFamily(CassandraEquivalenceSummaryStore.EQUIV_SUM_CF);
     }
-    
+
+    @Test
+    public void testLegacyContentWithEquivalentFromOnePublisher() throws ConnectionException {
+        cqlStatement.withCql("INSERT INTO \"EquivalenceSummaries\" (key, column1, value) "
+                + "VALUES ( 'three', 'summary', '{\"subject\":\"three\", \"parent\":\"parent\", \"candidates\":[\"one\"],\"equivalents\":{\"bbc.co.uk\":{\"canonicalUri\":\"uri\",\"publisher\":\"pressassociation.com\",\"parentUri\":\"parent\"}}}')");
+        cqlStatement.execute();
+        OptionalMap<String, EquivalenceSummary> resolved = store.summariesForUris(ImmutableSet.of("three"));
+        EquivalenceSummary summary = resolved.get("three").get();
+        assertThat(summary.getSubject(), is(equalTo("three")));
+        assertThat(summary.getParent(), is(equalTo("parent")));
+        assertThat(summary.getCandidates(), is(equalTo(ImmutableList.of("one"))));
+        assertThat(summary.getEquivalents().values().asList().get(0).getCanonicalUri(), is(equalTo("uri")));
+        assertThat(summary.getEquivalents().values().asList().get(0).getParentUri(), is(equalTo("parent")));
+        assertThat(summary.getEquivalents().values().asList().get(0).getPublisher(), is(equalTo(Publisher.PA)));
+    }
+
+    @Test
+    public void testLegacyContentWithEquivalentFromOnePublisherWithNoCandidates() throws ConnectionException {
+        cqlStatement.withCql("INSERT INTO \"EquivalenceSummaries\" (key, column1, value) "
+                + "VALUES ( 'three', 'summary', '{\"subject\":\"three\",\"candidates\":[],\"equivalents\":{\"bbc.co.uk\":{\"canonicalUri\":\"uri\",\"publisher\":\"pressassociation.com\",\"parentUri\":\"parent\"}}}')");
+        cqlStatement.execute();
+        OptionalMap<String, EquivalenceSummary> resolved = store.summariesForUris(ImmutableSet.of("three"));
+        EquivalenceSummary summary = resolved.get("three").get();
+        assertThat(summary.getSubject(), is(equalTo("three")));
+        assertThat(summary.getCandidates(), is(equalTo(ImmutableList.of())));
+        assertThat(summary.getEquivalents().values().asList().get(0).getCanonicalUri(), is(equalTo("uri")));
+        assertThat(summary.getEquivalents().values().asList().get(0).getParentUri(), is(equalTo("parent")));
+        assertThat(summary.getEquivalents().values().asList().get(0).getPublisher(), is(equalTo(Publisher.PA)));
+    }
+
+    @Test
+    public void testLegacyContentWithNoEquivalents() throws ConnectionException {
+        cqlStatement.withCql("INSERT INTO \"EquivalenceSummaries\" (key, column1, value) "
+                + "VALUES ( 'three', 'summary', '{\"subject\":\"three\",\"candidates\":[],\"equivalents\":{}}')");
+        cqlStatement.execute();
+        OptionalMap<String, EquivalenceSummary> resolved = store.summariesForUris(ImmutableSet.of("three"));
+        EquivalenceSummary summary = resolved.get("three").get();
+        assertThat(summary.getSubject(), is(equalTo("three")));
+        assertThat(summary.getCandidates(), is(equalTo(ImmutableList.of())));
+        assertThat(summary.getEquivalents().values().asList(), is(ImmutableList.of()));
+    }
+
     @Test
     public void testStoresAndResolvesSummaries() {
         
-        ImmutableMap<Publisher, ContentRef> refs = ImmutableMap.<Publisher, ContentRef>of(
+        ImmutableMultimap<Publisher, ContentRef> refs = ImmutableMultimap.<Publisher, ContentRef>of(
             Publisher.BBC, new ContentRef("uri", Publisher.PA, "parent")
         );
         EquivalenceSummary summaryOne = new EquivalenceSummary("one", null, ImmutableSet.of("one"), refs);
@@ -84,6 +138,30 @@ public class CassandraEquivalenceSummaryStoreTest {
         assertThat(resolved.get("two").get(), is(equalTo(summaryTwo)));
         assertThat(resolved.get("one").get(), is(equalTo(summaryOne)));
         
+    }
+
+    @Test
+    public void testStoresAndResolvesSummariesWithSeveralEquivalentsFromSamePublisher() {
+
+        ImmutableMultimap<Publisher, ContentRef> refs = ImmutableMultimap.<Publisher, ContentRef>of(
+                Publisher.BBC, new ContentRef("uri", Publisher.PA, "parent"),
+                Publisher.BBC, new ContentRef("uri2", Publisher.PA, "parent2"),
+                Publisher.PA, new ContentRef("uri3", Publisher.AMAZON_UK, "parent3"),
+                Publisher.PA, new ContentRef("uri4", Publisher.ADAPT_BBC_PODCASTS, "parent4"),
+                Publisher.VF_C5, new ContentRef("uri5", Publisher.ARQIVA, "parent5")
+        );
+
+        EquivalenceSummary summaryOne = new EquivalenceSummary(
+                "one",
+                null,
+                ImmutableSet.of("one"),
+                refs
+        );
+        store.store(summaryOne);
+        OptionalMap<String, EquivalenceSummary> resolved = store.summariesForUris(ImmutableSet.of("one"));
+
+        assertThat(resolved.get("one").get(), is(equalTo(summaryOne)));
+
     }
 
 }


### PR DESCRIPTION
to allow content to be equivalated to more than one publisher.

1.Change serialization and deserialization logic
2.Added new inner model for EquivalenceSummary that also holds other equivalence to allow safe deserialization
3.Written new tests