### PR TITLE
add option to skip cache to channel store

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
                     <source>1.8</source>
                     <target>1.8</target>
                     <fork>true</fork>
+                    <encoding>UTF-8</encoding>
                     <compilerArgs>
                         <arg>-J-Xss1M</arg>
                     </compilerArgs>

--- a/src/main/java/org/atlasapi/media/channel/CachingChannelStore.java
+++ b/src/main/java/org/atlasapi/media/channel/CachingChannelStore.java
@@ -62,9 +62,22 @@ public class CachingChannelStore implements ChannelStore, ServiceChannelStore {
 
     @Override
     public Maybe<Channel> fromId(long id) {
-        for (Channel channel : channels.get()) {
-            if (channel.getId().equals(id)) { 
-                return Maybe.just(channel);
+        return fromId(id, false);
+    }
+
+    @Override
+    public Maybe<Channel> fromIdSkipCache(long id) {
+        return fromId(id, true);
+    }
+
+    public Maybe<Channel> fromId(long id, boolean skipCache) {
+        if (skipCache) {
+            delegate.fromId(id);
+        } else {
+            for (Channel channel : channels.get()) {
+                if (channel.getId().equals(id)) {
+                    return Maybe.just(channel);
+                }
             }
         }
         return Maybe.nothing();
@@ -82,12 +95,21 @@ public class CachingChannelStore implements ChannelStore, ServiceChannelStore {
 
     @Override
     public Iterable<Channel> forIds(final Iterable<Long> ids) {
-        return Iterables.filter(channels.get(), new Predicate<Channel>() {
-                @Override
-                public boolean apply(Channel input) {
-                    return Iterables.contains(ids, input.getId());
-                }
-            });
+        return forIds(ids, false);
+    }
+
+    @Override
+    public Iterable<Channel> forIdsSkipCache(Iterable<Long> ids) {
+        return forIds(ids, true);
+    }
+
+    private Iterable<Channel> forIds(Iterable<Long> ids, boolean skipCache) {
+        if (skipCache) {
+            return delegate.forIds(ids);
+        } else {
+            return Iterables.filter(channels.get(),
+                    input -> Iterables.contains(ids, input.getId()));
+        }
     }
 
     @Override

--- a/src/main/java/org/atlasapi/media/channel/ChannelResolver.java
+++ b/src/main/java/org/atlasapi/media/channel/ChannelResolver.java
@@ -11,9 +11,13 @@ public interface ChannelResolver {
 
     Maybe<Channel> fromId(long id);
 
+    Maybe<Channel> fromIdSkipCache(long id);
+
     Maybe<Channel> fromUri(String uri);
 
     Iterable<Channel> forIds(Iterable<Long> ids);
+
+    Iterable<Channel> forIdsSkipCache(Iterable<Long> ids);
 
     Iterable<Channel> all();
 

--- a/src/main/java/org/atlasapi/media/channel/MongoChannelStore.java
+++ b/src/main/java/org/atlasapi/media/channel/MongoChannelStore.java
@@ -127,6 +127,11 @@ public class MongoChannelStore implements ServiceChannelStore {
     }
 
     @Override
+    public Maybe<Channel> fromIdSkipCache(long id) {
+        throw new UnsupportedOperationException("Channel store does not have a cache");
+    }
+
+    @Override
     public Maybe<Channel> fromUri(final String uri) {
         return Maybe.fromPossibleNullValue(
                 translator.fromDBObject(
@@ -142,6 +147,11 @@ public class MongoChannelStore implements ServiceChannelStore {
                 getOrderedCursor(where().longIdIn(ids).build()),
                 DB_TO_CHANNEL_TRANSLATOR::apply
         );
+    }
+
+    @Override
+    public Iterable<Channel> forIdsSkipCache(Iterable<Long> ids) {
+        throw new UnsupportedOperationException("Channel store does not have a cache");
     }
 
     @Override

--- a/src/test/java/org/atlasapi/persistence/channels/DummyChannelResolver.java
+++ b/src/test/java/org/atlasapi/persistence/channels/DummyChannelResolver.java
@@ -48,6 +48,11 @@ public class DummyChannelResolver implements ChannelResolver {
 	}
 
 	@Override
+	public Maybe<Channel> fromIdSkipCache(long id) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public Maybe<Channel> fromUri(String uri) {
 	    return Maybe.fromPossibleNullValue(channels.get(uri));
 	}
@@ -66,6 +71,11 @@ public class DummyChannelResolver implements ChannelResolver {
     public Iterable<Channel> forIds(Iterable<Long> ids) {
         throw new UnsupportedOperationException();
     }
+
+	@Override
+	public Iterable<Channel> forIdsSkipCache(Iterable<Long> ids) {
+		throw new UnsupportedOperationException();
+	}
 
     @Override
     public Maybe<Channel> forAlias(String alias) {


### PR DESCRIPTION
Deer uses the mongo caching channel store to fetch channels from mongo. We don't want to switch it to the uncached store so an option to skip as been added which will be called if a parameter is present in a deer channel call.