### PR TITLE
Filter out unpublished refs in getEquivSetByFollowingLinks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-persistence</artifactId>
-    <version>5.2-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
     <build>
         <finalName>atlas-persistence</finalName>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-persistence</artifactId>
-    <version>5.1-SNAPSHOT</version>
+    <version>5.2-SNAPSHOT</version>
     <build>
         <finalName>atlas-persistence</finalName>
         <plugins>
@@ -186,7 +186,7 @@
     
     <properties>
         <atlas.version>5.0-SNAPSHOT</atlas.version>
-        <common.version>1.1-SNAPSHOT</common.version>
+        <common.version>1.0-SNAPSHOT</common.version>
         <common-queue.version>2.0-SNAPSHOT</common-queue.version>
         <spring.version>4.0.9.RELEASE</spring.version>
         <amq.version>5.9.0</amq.version>

--- a/src/main/java/org/atlasapi/persistence/MongoContentPersistenceModule.java
+++ b/src/main/java/org/atlasapi/persistence/MongoContentPersistenceModule.java
@@ -69,6 +69,7 @@ public class MongoContentPersistenceModule implements ContentPersistenceModule {
 
     public static final String NON_ID_SETTING_CONTENT_WRITER = "nonIdSettingContentWriter";
     public static final String NON_ID_NO_LOCK_SETTING_CONTENT_WRITER = "nonIdNoLockSettingContentWriter";
+    public static final String CONTENT_CHANGES_PRODUCER = "contentChangesProducer";
 
     @Autowired private ReadPreference readPreference;
     @Autowired private Mongo mongo;
@@ -143,7 +144,7 @@ public class MongoContentPersistenceModule implements ContentPersistenceModule {
         );
     }
 
-    @Bean
+    @Bean(name = CONTENT_CHANGES_PRODUCER)
     @Lazy(true)
     public MessageSender<EntityUpdatedMessage> contentChanges() {
         return persistenceModule().contentChanges();

--- a/src/main/java/org/atlasapi/persistence/MongoContentPersistenceModule.java
+++ b/src/main/java/org/atlasapi/persistence/MongoContentPersistenceModule.java
@@ -143,7 +143,7 @@ public class MongoContentPersistenceModule implements ContentPersistenceModule {
         );
     }
 
-    @Bean()
+    @Bean
     @Lazy(true)
     public MessageSender<EntityUpdatedMessage> contentChanges() {
         return persistenceModule().contentChanges();

--- a/src/main/java/org/atlasapi/persistence/MongoContentPersistenceModule.java
+++ b/src/main/java/org/atlasapi/persistence/MongoContentPersistenceModule.java
@@ -69,7 +69,6 @@ public class MongoContentPersistenceModule implements ContentPersistenceModule {
 
     public static final String NON_ID_SETTING_CONTENT_WRITER = "nonIdSettingContentWriter";
     public static final String NON_ID_NO_LOCK_SETTING_CONTENT_WRITER = "nonIdNoLockSettingContentWriter";
-    public static final String CONTENT_CHANGES_PRODUCER = "contentChangesProducer";
 
     @Autowired private ReadPreference readPreference;
     @Autowired private Mongo mongo;
@@ -144,7 +143,7 @@ public class MongoContentPersistenceModule implements ContentPersistenceModule {
         );
     }
 
-    @Bean(name = CONTENT_CHANGES_PRODUCER)
+    @Bean()
     @Lazy(true)
     public MessageSender<EntityUpdatedMessage> contentChanges() {
         return persistenceModule().contentChanges();

--- a/src/main/java/org/atlasapi/persistence/content/DefaultEquivalentContentResolver.java
+++ b/src/main/java/org/atlasapi/persistence/content/DefaultEquivalentContentResolver.java
@@ -289,7 +289,10 @@ public class DefaultEquivalentContentResolver implements EquivalentContentResolv
         }
 
         return collectedEquivsAndPublishedState.keySet().stream()
-                .filter(collectedEquivsAndPublishedState::get) //filter to just published
+                .filter(ref ->
+                        ref.equals(startingContent.lookupRef())  //always include yourself, even if unpublished
+                                || collectedEquivsAndPublishedState.get(ref) //filter to just published
+                )
                 .collect(MoreCollectors.toImmutableSet());
     }
 

--- a/src/main/java/org/atlasapi/persistence/content/DefaultEquivalentContentResolver.java
+++ b/src/main/java/org/atlasapi/persistence/content/DefaultEquivalentContentResolver.java
@@ -269,10 +269,7 @@ public class DefaultEquivalentContentResolver implements EquivalentContentResolv
         }
 
         return collectedEquivsAndPublishedState.keySet().stream()
-                .filter(ref ->
-                        ref.equals(startingContent.lookupRef())  //always include yourself, even if unpublished
-                                || collectedEquivsAndPublishedState.get(ref) //filter to just published
-                )
+                .filter(collectedEquivsAndPublishedState::get) //filter to just published
                 .collect(MoreCollectors.toImmutableSet());
     }
 

--- a/src/main/java/org/atlasapi/persistence/content/DefaultEquivalentContentResolver.java
+++ b/src/main/java/org/atlasapi/persistence/content/DefaultEquivalentContentResolver.java
@@ -5,6 +5,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
@@ -15,27 +16,37 @@ import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
 import com.metabroadcast.applications.client.model.internal.Application;
 import com.metabroadcast.common.base.MorePredicates;
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
+import com.metabroadcast.common.queue.MessageSender;
 import com.metabroadcast.common.stream.MoreCollectors;
+import com.metabroadcast.common.time.SystemClock;
+import com.metabroadcast.common.time.Timestamper;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.LookupRef;
 import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.messaging.v3.EntityUpdatedMessage;
 import org.atlasapi.output.Annotation;
 import org.atlasapi.persistence.lookup.entry.LookupEntry;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
+import java.math.BigInteger;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.atlasapi.output.Annotation.RESPECT_API_KEY_FOR_EQUIV_LIST;
+import static org.atlasapi.persistence.MongoContentPersistenceModule.CONTENT_CHANGES_PRODUCER;
 
 public class DefaultEquivalentContentResolver implements EquivalentContentResolver {
 
@@ -43,6 +54,10 @@ public class DefaultEquivalentContentResolver implements EquivalentContentResolv
     private LookupEntryStore lookupResolver;
     private final Ordering<LookupRef> nullSafeRefById = Ordering.natural().onResultOf(LookupRef.TO_ID).nullsLast();
     private final Logger log = LoggerFactory.getLogger(DefaultEquivalentContentResolver.class);
+
+    @Autowired @Qualifier(CONTENT_CHANGES_PRODUCER) private MessageSender<EntityUpdatedMessage> contentChangesProducer;
+    private final SubstitutionTableNumberCodec entityIdCodec = SubstitutionTableNumberCodec.lowerCaseOnly();
+    private final Timestamper clock = new SystemClock();
 
     public DefaultEquivalentContentResolver(
             KnownTypeContentResolver contentResolver,
@@ -241,6 +256,11 @@ public class DefaultEquivalentContentResolver implements EquivalentContentResolv
 
             for(LookupEntry entry : resolvedEntries) {
                 collectedEquivsAndPublishedState.putIfAbsent(entry.lookupRef(), entry.activelyPublished());
+                if(!entry.activelyPublished()) {
+                    //try to have equiv run on this content again so it might be removed from the equiv set next time
+                    //it is queried
+                    triggerEquivalenceUpdate(entry.lookupRef());
+                }
             }
 
             //and do the same for the next set, until there are no more links to follow.
@@ -355,6 +375,27 @@ public class DefaultEquivalentContentResolver implements EquivalentContentResolv
                 .sortedCopy(application.getConfiguration().getEnabledReadSources())
                 .get(0)
                 .equals(entry.lookupRef().publisher());
+    }
+
+    //write a message on the content changes queue in order for equivalence to be run again
+    private void triggerEquivalenceUpdate(LookupRef lookupRef) {
+        ResolvedContent resolvedContent = contentResolver.findByLookupRefs(ImmutableList.of(lookupRef));
+        if (resolvedContent.getFirstValue().hasValue()) {
+            Identified identified = resolvedContent.getFirstValue().requireValue();
+            try {
+                contentChangesProducer.sendMessage(
+                        new EntityUpdatedMessage(
+                                UUID.randomUUID().toString(),
+                                clock.timestamp(),
+                                entityIdCodec.encode(BigInteger.valueOf(lookupRef.id())),
+                                identified.getClass().getSimpleName().toLowerCase(),
+                                lookupRef.publisher().key()
+                        )
+                );
+            } catch (Exception e) {
+                log.error("update message failed: " + identified, e);
+            }
+        }
     }
 
 }

--- a/src/test/java/org/atlasapi/persistence/content/DefaultEquivalentContentResolverTest.java
+++ b/src/test/java/org/atlasapi/persistence/content/DefaultEquivalentContentResolverTest.java
@@ -244,6 +244,7 @@ public class DefaultEquivalentContentResolverTest {
         lookupResolver.store(subjEntry);
         lookupResolver.store(entry(expEquivRead, expEquivReadTransNoRead, expEquivReadTransRead));
         lookupResolver.store(entry(expEquivNoReadTransRead, expEquivNoReadTransNoRead, expEquivNoReadTransRead));
+        lookupResolver.store(entry(expEquivReadTransRead));
 
         Set<LookupRef> processedRefs = resolver.getEquivSetByFollowingLinks(subjEntry, sourceFilter);
 

--- a/src/test/java/org/atlasapi/persistence/content/DefaultEquivalentContentResolverTest.java
+++ b/src/test/java/org/atlasapi/persistence/content/DefaultEquivalentContentResolverTest.java
@@ -1,12 +1,14 @@
 package org.atlasapi.persistence.content;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
+import com.google.common.base.Predicates;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import com.metabroadcast.applications.client.model.internal.Application;
+import com.metabroadcast.applications.client.model.internal.ApplicationConfiguration;
+import com.metabroadcast.common.base.MorePredicates;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Identified;
@@ -16,19 +18,14 @@ import org.atlasapi.output.Annotation;
 import org.atlasapi.persistence.lookup.InMemoryLookupEntryStore;
 import org.atlasapi.persistence.lookup.entry.LookupEntry;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
-
-import com.metabroadcast.applications.client.model.internal.Application;
-import com.metabroadcast.applications.client.model.internal.ApplicationConfiguration;
-import com.metabroadcast.common.base.MorePredicates;
-
-import com.google.common.base.Predicates;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
@@ -308,8 +305,7 @@ public class DefaultEquivalentContentResolverTest {
 
         Set<LookupRef> processedRefs = resolver.getEquivSetByFollowingLinks(subjEntry, sourceFilter);
 
-        assertThat(processedRefs.size(), is(1));
-        assertTrue(processedRefs.contains(LookupRef.from(subject)));
+        assertThat(processedRefs.size(), is(0));
     }
 
     private ApplicationConfiguration configWithSources(Publisher... srcs) {


### PR DESCRIPTION
The equivs returned by this method would include unpublished content
along with potentially published content that is equived to the
unpublished content. As a result you could see published content
returned that is not reachable except through a link on unpublished
content.
This change filters out unpublished content before querying for
its direct/explicit equivalences, and filters out the LookupRefs it
had found when returning.