### PR TITLE
Added method to include/exclude unpublished entries in LookupEntryStore

### DIFF
--- a/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
@@ -1,13 +1,12 @@
 package org.atlasapi.persistence.lookup.entry;
 
-import java.util.Map;
-
-import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.persistence.content.listing.ContentListingProgress;
-
 import com.google.common.base.Optional;
 import com.metabroadcast.common.query.Selection;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.persistence.content.listing.ContentListingProgress;
 import org.joda.time.DateTime;
+
+import java.util.Map;
 
 public interface LookupEntryStore {
 
@@ -30,13 +29,27 @@ public interface LookupEntryStore {
     Iterable<LookupEntry> entriesForIdentifiers(Iterable<String> identifiers, boolean useAliases);
     
     /**
-     * Get entries for specified namespace and values.
+     * Get entries for specified namespace and values. Includes unpublished entries.
      * 
      * @param namespace - not always present
      * @param values - one or more corresponding alias values
      * @return
      */
     Iterable<LookupEntry> entriesForAliases(Optional<String> namespace, Iterable<String> values);
+
+    /**
+     * Get entries for specified namespace and values.
+     *
+     * @param namespace - not always present
+     * @param values - one or more corresponding alias values
+     * @param includeUnpublishedEntries - include unpublished content
+     * @return
+     */
+    Iterable<LookupEntry> entriesForAliases(
+            Optional<String> namespace,
+            Iterable<String> values,
+            boolean includeUnpublishedEntries
+    );
 
     /**
      * Get entries for specified <b>canonical</b> URIs.


### PR DESCRIPTION
BARB equivalence is resolving unpublished content only to filter it
out later on and so this acts as a performance improvement to simply
not return the unpublished entries in the first place.