### PR TITLE
Fix cursor timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-persistence</artifactId>
-    <version>5.0-SNAPSHOT</version>
+    <version>5.5-SNAPSHOT</version>
     <build>
         <finalName>atlas-persistence</finalName>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-persistence</artifactId>
-    <version>5.5-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
     <build>
         <finalName>atlas-persistence</finalName>
         <plugins>

--- a/src/main/java/org/atlasapi/persistence/content/listing/SelectedContentLister.java
+++ b/src/main/java/org/atlasapi/persistence/content/listing/SelectedContentLister.java
@@ -7,7 +7,7 @@ import org.atlasapi.media.entity.Content;
 
 public interface SelectedContentLister {
 
-    List<Content> listContent(ContentListingCriteria criteria, boolean preloadAllContent);
+    List<String> listContent(ContentListingCriteria criteria, boolean preloadAllContent);
 
     Iterator<Content> listContent(ContentListingCriteria criteria);
 

--- a/src/main/java/org/atlasapi/persistence/content/listing/SelectedContentLister.java
+++ b/src/main/java/org/atlasapi/persistence/content/listing/SelectedContentLister.java
@@ -1,0 +1,13 @@
+package org.atlasapi.persistence.content.listing;
+
+import java.util.Iterator;
+
+import org.atlasapi.media.entity.Content;
+
+import com.metabroadcast.common.persistence.mongo.MongoSelectBuilder;
+
+public interface SelectedContentLister {
+
+    Iterator<Content> listContent(ContentListingCriteria criteria, boolean fetchSelected);
+
+}

--- a/src/main/java/org/atlasapi/persistence/content/listing/SelectedContentLister.java
+++ b/src/main/java/org/atlasapi/persistence/content/listing/SelectedContentLister.java
@@ -1,13 +1,12 @@
 package org.atlasapi.persistence.content.listing;
 
 import java.util.Iterator;
-import java.util.List;
 
 import org.atlasapi.media.entity.Content;
 
 public interface SelectedContentLister {
 
-    List<String> listContentUris(ContentListingCriteria criteria);
+    Iterator<String> listContentUris(ContentListingCriteria criteria);
 
     Iterator<Content> listContent(ContentListingCriteria criteria);
 

--- a/src/main/java/org/atlasapi/persistence/content/listing/SelectedContentLister.java
+++ b/src/main/java/org/atlasapi/persistence/content/listing/SelectedContentLister.java
@@ -7,7 +7,7 @@ import org.atlasapi.media.entity.Content;
 
 public interface SelectedContentLister {
 
-    List<String> listContent(ContentListingCriteria criteria, boolean preloadAllContent);
+    List<String> listContentUris(ContentListingCriteria criteria, boolean preloadAllContent);
 
     Iterator<Content> listContent(ContentListingCriteria criteria);
 

--- a/src/main/java/org/atlasapi/persistence/content/listing/SelectedContentLister.java
+++ b/src/main/java/org/atlasapi/persistence/content/listing/SelectedContentLister.java
@@ -1,12 +1,13 @@
 package org.atlasapi.persistence.content.listing;
 
 import java.util.Iterator;
+import java.util.List;
 
 import org.atlasapi.media.entity.Content;
 
 public interface SelectedContentLister {
 
-    Iterator<String> listContentUris(ContentListingCriteria criteria);
+    List<String> listContentUris(ContentListingCriteria criteria);
 
     Iterator<Content> listContent(ContentListingCriteria criteria);
 

--- a/src/main/java/org/atlasapi/persistence/content/listing/SelectedContentLister.java
+++ b/src/main/java/org/atlasapi/persistence/content/listing/SelectedContentLister.java
@@ -7,7 +7,7 @@ import org.atlasapi.media.entity.Content;
 
 public interface SelectedContentLister {
 
-    List<String> listContentUris(ContentListingCriteria criteria, boolean preloadAllContent);
+    List<String> listContentUris(ContentListingCriteria criteria);
 
     Iterator<Content> listContent(ContentListingCriteria criteria);
 

--- a/src/main/java/org/atlasapi/persistence/content/listing/SelectedContentLister.java
+++ b/src/main/java/org/atlasapi/persistence/content/listing/SelectedContentLister.java
@@ -1,13 +1,14 @@
 package org.atlasapi.persistence.content.listing;
 
 import java.util.Iterator;
+import java.util.List;
 
 import org.atlasapi.media.entity.Content;
 
-import com.metabroadcast.common.persistence.mongo.MongoSelectBuilder;
-
 public interface SelectedContentLister {
 
-    Iterator<Content> listContent(ContentListingCriteria criteria, boolean fetchSelected);
+    List<Content> listContent(ContentListingCriteria criteria, boolean preloadAllContent);
+
+    Iterator<Content> listContent(ContentListingCriteria criteria);
 
 }

--- a/src/main/java/org/atlasapi/persistence/content/mongo/MongoContentLister.java
+++ b/src/main/java/org/atlasapi/persistence/content/mongo/MongoContentLister.java
@@ -1,5 +1,7 @@
 package org.atlasapi.persistence.content.mongo;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -88,18 +90,20 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
     }
 
     @Override
-    public Iterator<String> listContentUris(ContentListingCriteria criteria) {
+    public List<String> listContentUris(ContentListingCriteria criteria) {
         List<Publisher> publishers = remainingPublishers(criteria);
 
         if(publishers.isEmpty()) {
-            return Iterators.emptyIterator();
+            return Collections.emptyList();
         }
 
         Iterator<Content> contentIterator = iteratorsFor(publishers, criteria, true);
         Iterator<String> uriIterator = Iterators.transform(contentIterator,
                 Identified::getCanonicalUri
         );
-        return uriIterator;
+        List<String> allContent = new ArrayList<>();
+        uriIterator.forEachRemaining(allContent::add);
+        return allContent;
     }
 
     private Iterator<Content> iteratorsFor(final List<Publisher> publishers,

--- a/src/main/java/org/atlasapi/persistence/content/mongo/MongoContentLister.java
+++ b/src/main/java/org/atlasapi/persistence/content/mongo/MongoContentLister.java
@@ -1,14 +1,5 @@
 package org.atlasapi.persistence.content.mongo;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.metabroadcast.common.persistence.mongo.MongoBuilders.sort;
-import static com.metabroadcast.common.persistence.mongo.MongoBuilders.where;
-import static com.metabroadcast.common.persistence.mongo.MongoConstants.ID;
-import static org.atlasapi.persistence.content.ContentCategory.CHILD_ITEM;
-import static org.atlasapi.persistence.content.ContentCategory.CONTAINER;
-import static org.atlasapi.persistence.content.ContentCategory.PROGRAMME_GROUP;
-import static org.atlasapi.persistence.content.ContentCategory.TOP_LEVEL_ITEM;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -31,9 +22,14 @@ import org.atlasapi.persistence.media.entity.ContainerTranslator;
 import org.atlasapi.persistence.media.entity.DescribedTranslator;
 import org.atlasapi.persistence.media.entity.ItemTranslator;
 import org.atlasapi.persistence.topic.TopicContentLister;
-import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
+import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
+import com.metabroadcast.common.persistence.mongo.MongoConstants;
+import com.metabroadcast.common.persistence.mongo.MongoQueryBuilder;
+import com.metabroadcast.common.persistence.mongo.MongoSelectBuilder;
+import com.metabroadcast.common.persistence.mongo.MongoSortBuilder;
+import com.metabroadcast.common.persistence.translator.TranslatorUtils;
 
 import com.google.common.base.Function;
 import com.google.common.base.Strings;
@@ -42,26 +38,31 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
-import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
-import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
-import com.metabroadcast.common.persistence.mongo.MongoConstants;
-import com.metabroadcast.common.persistence.mongo.MongoQueryBuilder;
-import com.metabroadcast.common.persistence.mongo.MongoSelectBuilder;
-import com.metabroadcast.common.persistence.mongo.MongoSortBuilder;
-import com.metabroadcast.common.persistence.translator.TranslatorUtils;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.Bytes;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class MongoContentLister implements ContentLister, LastUpdatedContentFinder, TopicContentLister,
-        EventContentLister, SelectedContentLister {
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.metabroadcast.common.persistence.mongo.MongoBuilders.sort;
+import static com.metabroadcast.common.persistence.mongo.MongoBuilders.where;
+import static com.metabroadcast.common.persistence.mongo.MongoConstants.ID;
+import static org.atlasapi.persistence.content.ContentCategory.CHILD_ITEM;
+import static org.atlasapi.persistence.content.ContentCategory.CONTAINER;
+import static org.atlasapi.persistence.content.ContentCategory.PROGRAMME_GROUP;
+import static org.atlasapi.persistence.content.ContentCategory.TOP_LEVEL_ITEM;
+
+public class MongoContentLister implements ContentLister, LastUpdatedContentFinder,
+        TopicContentLister, EventContentLister, SelectedContentLister {
 
     private static final Logger log = LoggerFactory.getLogger(MongoContentLister.class);
-    
+
     private static final Long NULL_ID = null;
     private static final Publisher NULL_PUBLISHER = null;
-    
+
 
     private final ContainerTranslator containerTranslator;
     private final ItemTranslator itemTranslator;
@@ -91,17 +92,17 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
     @Override
     public List<String> listContentUris(ContentListingCriteria criteria, boolean preloadAllContent) {
         List<Publisher> publishers = remainingPublishers(criteria);
-        
+
         if(publishers.isEmpty()) {
             return Collections.emptyList();
         }
 
         Iterator<Content> contentIterator = iteratorsFor(publishers, criteria, preloadAllContent);
-        Iterator<String> stringIterator = Iterators.transform(contentIterator,
+        Iterator<String> uriIterator = Iterators.transform(contentIterator,
                 Identified::getCanonicalUri
         );
         List<String> allContent = new ArrayList<>();
-        stringIterator.forEachRemaining(allContent::add);
+        uriIterator.forEachRemaining(allContent::add);
         return allContent;
     }
 
@@ -115,7 +116,7 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
         final String uri = criteria.getProgress().getUri();
         final List<ContentCategory> initialCats = remainingTables(criteria);
         final List<ContentCategory> allCats = criteria.getCategories();
-        
+
         return Iterators.concat(Iterators.transform(publishers.iterator(), new Function<Publisher, Iterator<Content>>() {
             @Override
             public Iterator<Content> apply(final Publisher publisher) {
@@ -154,29 +155,29 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
                     }
 
                 });
-                
+
             }
             private <T> boolean first(T e, List<T> es) {
                 return e.equals(es.get(0));
             }
         }));
     }
-    
+
 
     private List<Publisher> remainingPublishers(ContentListingCriteria criteria) {
         List<Publisher> publishers = criteria.getPublishers().isEmpty() ? ImmutableList.copyOf(Publisher.values()) : criteria.getPublishers();
         Publisher currentPublisher = criteria.getProgress().getPublisher();
-        
+
         return publishers.subList(currentPublisher == null ? 0 : publishers.indexOf(currentPublisher), publishers.size());
     }
 
     private List<ContentCategory> remainingTables(ContentListingCriteria criteria) {
         List<ContentCategory> tables = criteria.getCategories().isEmpty() ? ImmutableList.copyOf(ContentCategory.values()) : criteria.getCategories();
         ContentCategory currentTable = criteria.getProgress().getCategory();
-        
+
         return tables.subList(currentTable == null ? 0 : tables.indexOf(currentTable), tables.size());
     }
-    
+
     private static final List<ContentCategory> BRAND_SERIES_AND_ITEMS_TABLES = ImmutableList.of(CONTAINER, PROGRAMME_GROUP, TOP_LEVEL_ITEM, CHILD_ITEM);
 
     @Override
@@ -204,7 +205,7 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
             private final Iterator<ContentCategory> tablesIt = tables.iterator();
             private Iterator<DBObject> currentResults = Iterators.emptyIterator();
             private Function<DBObject, T> currentTranslator;
-            
+
             @Override
             protected T computeNext() {
                 while (!currentResults.hasNext()) {
@@ -214,7 +215,7 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
                     ContentCategory table = tablesIt.next();
                     currentTranslator = cursorBuilder.translatorFor(table);
                     if (currentTranslator == null) {
-                       log.error("No translator found for content category " + table.toString()); 
+                       log.error("No translator found for content category " + table.toString());
                     }
                     currentResults = cursorBuilder.cursorFor(table);
                 }
@@ -229,7 +230,7 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
             return containerTranslator.fromDBObject(input, null);
         }
     };
-    
+
     private final Function<DBObject, Item> TO_ITEM = new Function<DBObject, Item>() {
         @Override
         public Item apply(DBObject input) {
@@ -238,9 +239,9 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
     };
 
     private final ImmutableMap<ContentCategory, Function<DBObject, ? extends Content>> TRANSLATORS = ImmutableMap.<ContentCategory, Function<DBObject, ? extends Content>>of(
-            CHILD_ITEM, TO_ITEM, 
-            PROGRAMME_GROUP, TO_CONTAINER, 
-            TOP_LEVEL_ITEM, TO_ITEM, 
+            CHILD_ITEM, TO_ITEM,
+            PROGRAMME_GROUP, TO_CONTAINER,
+            TOP_LEVEL_ITEM, TO_ITEM,
             CONTAINER, TO_CONTAINER);
 
     @Override
@@ -271,12 +272,12 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
     }
 
     private interface ListingCursorBuilder<T> {
-        
+
         DBCursor cursorFor(ContentCategory category);
         Function<DBObject, T> translatorFor(ContentCategory contentCategory);
-        
+
     }
-    
+
     @Override
     //TODO: enable use of contentQuery?
     public Iterator<Content> contentForTopic(final Long topicId, ContentQuery contentQuery) {
@@ -297,17 +298,17 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
             }
         });
         Iterable<LookupRef> selectionToResolve = contentQuery.getSelection().applyTo(allCanonicalUris);
-        
+
         return Iterables
                 .filter(
-                        contentResolver.findByLookupRefs(selectionToResolve).getAllResolvedResults(), 
+                        contentResolver.findByLookupRefs(selectionToResolve).getAllResolvedResults(),
                         Content.class
                        ).iterator();
     }
 
     private Function<DBObject, LookupRef> toLookupRef(final ContentCategory category) {
         return new Function<DBObject, LookupRef>() {
-    
+
             @Override
             public LookupRef apply(DBObject input) {
                 String uri = TranslatorUtils.toString(input, MongoConstants.ID);
@@ -315,7 +316,7 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
             }
         };
     }
-    
+
     private Function<DBObject, Content> toContentFunction(ContentCategory category) {
         return (Function<DBObject, Content>) TRANSLATORS.get(category);
     }

--- a/src/main/java/org/atlasapi/persistence/content/mongo/MongoContentLister.java
+++ b/src/main/java/org/atlasapi/persistence/content/mongo/MongoContentLister.java
@@ -1,7 +1,5 @@
 package org.atlasapi.persistence.content.mongo;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -90,20 +88,18 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
     }
 
     @Override
-    public List<String> listContentUris(ContentListingCriteria criteria) {
+    public Iterator<String> listContentUris(ContentListingCriteria criteria) {
         List<Publisher> publishers = remainingPublishers(criteria);
 
         if(publishers.isEmpty()) {
-            return Collections.emptyList();
+            return Iterators.emptyIterator();
         }
 
         Iterator<Content> contentIterator = iteratorsFor(publishers, criteria, true);
         Iterator<String> uriIterator = Iterators.transform(contentIterator,
                 Identified::getCanonicalUri
         );
-        List<String> allContent = new ArrayList<>();
-        uriIterator.forEachRemaining(allContent::add);
-        return allContent;
+        return uriIterator;
     }
 
     private Iterator<Content> iteratorsFor(final List<Publisher> publishers,

--- a/src/main/java/org/atlasapi/persistence/content/mongo/MongoContentLister.java
+++ b/src/main/java/org/atlasapi/persistence/content/mongo/MongoContentLister.java
@@ -89,7 +89,7 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
     }
 
     @Override
-    public List<String> listContent(ContentListingCriteria criteria, boolean preloadAllContent) {
+    public List<String> listContentUris(ContentListingCriteria criteria, boolean preloadAllContent) {
         List<Publisher> publishers = remainingPublishers(criteria);
         
         if(publishers.isEmpty()) {

--- a/src/main/java/org/atlasapi/persistence/content/mongo/MongoContentLister.java
+++ b/src/main/java/org/atlasapi/persistence/content/mongo/MongoContentLister.java
@@ -90,29 +90,29 @@ public class MongoContentLister implements ContentLister, LastUpdatedContentFind
     }
 
     @Override
-    public List<String> listContentUris(ContentListingCriteria criteria) {
+    public Iterator<String> listContentUris(ContentListingCriteria criteria) {
         List<Publisher> publishers = remainingPublishers(criteria);
 
         if(publishers.isEmpty()) {
-            return Collections.emptyList();
+            return Iterators.emptyIterator();
         }
 
         Iterator<Content> contentIterator = iteratorsFor(publishers, criteria, true);
         Iterator<String> uriIterator = Iterators.transform(contentIterator,
                 Identified::getCanonicalUri
         );
-        List<String> allContent = new ArrayList<>();
-        uriIterator.forEachRemaining(allContent::add);
-        return allContent;
+        return uriIterator;
     }
 
     private Iterator<Content> iteratorsFor(final List<Publisher> publishers,
             ContentListingCriteria criteria) {
+
         return iteratorsFor(publishers, criteria, false);
     }
 
     private Iterator<Content> iteratorsFor(final List<Publisher> publishers,
             ContentListingCriteria criteria, boolean fetchOnlyUris) {
+
         final String uri = criteria.getProgress().getUri();
         final List<ContentCategory> initialCats = remainingTables(criteria);
         final List<ContentCategory> allCats = criteria.getCategories();


### PR DESCRIPTION
This is part of a workaround to prevent MongoCursorNotFoundException which stopped equiv from properly rerunning on all content from a publisher. The change is to use a List of content uris instead of an Iterator of Content.

https://metabroadcast.atlassian.net/browse/ENG-316