### PR TITLE
Transitive lookup writer transactions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-persistence</artifactId>
-    <version>5.0-SNAPSHOT</version>
+    <version>5.1-SNAPSHOT</version>
     <build>
         <finalName>atlas-persistence</finalName>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.metabroadcast.common.persistence</groupId>
             <artifactId>common-persistence</artifactId>
-            <version>${common.version}</version>
+            <version>${common.persistence.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.datastax.cassandra</groupId>
@@ -186,7 +186,7 @@
     
     <properties>
         <atlas.version>5.0-SNAPSHOT</atlas.version>
-        <common.version>1.0-SNAPSHOT</common.version>
+        <common.persistence.version>1.1-SNAPSHOT</common.persistence.version>
         <common-queue.version>2.0-SNAPSHOT</common-queue.version>
         <spring.version>4.0.9.RELEASE</spring.version>
         <amq.version>5.9.0</amq.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-persistence</artifactId>
-    <version>5.1-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
     <build>
         <finalName>atlas-persistence</finalName>
         <plugins>
@@ -186,7 +186,7 @@
     
     <properties>
         <atlas.version>5.0-SNAPSHOT</atlas.version>
-        <common.persistence.version>1.1-SNAPSHOT</common.persistence.version>
+        <common.persistence.version>1.0-SNAPSHOT</common.persistence.version>
         <common-queue.version>2.0-SNAPSHOT</common-queue.version>
         <spring.version>4.0.9.RELEASE</spring.version>
         <amq.version>5.9.0</amq.version>

--- a/src/main/java/org/atlasapi/persistence/ConstructorBasedMongoContentPersistenceModule.java
+++ b/src/main/java/org/atlasapi/persistence/ConstructorBasedMongoContentPersistenceModule.java
@@ -9,7 +9,6 @@ import com.metabroadcast.common.persistence.mongo.health.MongoIOProbe;
 import com.metabroadcast.common.properties.Parameter;
 import com.metabroadcast.common.queue.MessageSender;
 import com.metabroadcast.common.time.SystemClock;
-import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
@@ -327,8 +326,8 @@ public class ConstructorBasedMongoContentPersistenceModule implements ContentPer
 
     public MongoLookupEntryStore lookupStore() {
         return new MongoLookupEntryStore(
-                mongoDatabase.collection(LOOKUP, DBObject.class),
                 mongoDatabase,
+                LOOKUP,
                 persistenceAuditLog(),
                 readPreference
         );
@@ -346,8 +345,8 @@ public class ConstructorBasedMongoContentPersistenceModule implements ContentPer
 
     protected LookupWriter explicitLookupWriter() {
         MongoLookupEntryStore entryStore = new MongoLookupEntryStore(
-                mongoDatabase.collection(LOOKUP, DBObject.class),
                 mongoDatabase,
+                LOOKUP,
                 persistenceAuditLog(),
                 ReadPreference.primary()
         );
@@ -356,8 +355,8 @@ public class ConstructorBasedMongoContentPersistenceModule implements ContentPer
 
     public LookupWriter generatedLookupWriter() {
         MongoLookupEntryStore entryStore = new MongoLookupEntryStore(
-                mongoDatabase.collection(LOOKUP, DBObject.class),
                 mongoDatabase,
+                LOOKUP,
                 persistenceAuditLog(),
                 ReadPreference.primary()
         );
@@ -401,8 +400,8 @@ public class ConstructorBasedMongoContentPersistenceModule implements ContentPer
 
     public PersonStore personStore() {
         LookupEntryStore personLookupEntryStore = new MongoLookupEntryStore(
-                mongoDatabase.collection("peopleLookup", DBObject.class),
                 mongoDatabase,
+                "peopleLookup",
                 persistenceAuditLog(),
                 readPreference
         );
@@ -511,8 +510,8 @@ public class ConstructorBasedMongoContentPersistenceModule implements ContentPer
     public OrganisationStore organisationStore() {
 
         LookupEntryStore organisationLookupEntryStore = new MongoLookupEntryStore(
-                mongoDatabase.collection("organisationLookup", DBObject.class),
                 mongoDatabase,
+                "organisationLookup",
                 persistenceAuditLog(),
                 readPreference
         );
@@ -571,8 +570,8 @@ public class ConstructorBasedMongoContentPersistenceModule implements ContentPer
         return new EquivalatingPeopleResolver(
                 personStore(),
                 new MongoLookupEntryStore(
-                        mongoDatabase.collection("peopleLookup", DBObject.class),
                         mongoDatabase,
+                        "peopleLookup",
                         persistenceAuditLog(),
                         readPreference
                 )

--- a/src/main/java/org/atlasapi/persistence/MongoContentPersistenceModule.java
+++ b/src/main/java/org/atlasapi/persistence/MongoContentPersistenceModule.java
@@ -76,8 +76,8 @@ public class MongoContentPersistenceModule implements ContentPersistenceModule {
     @Autowired private ReadPreference readPreference;
     @Autowired private Mongo mongo;
     @Autowired private DatabasedMongo db;
-    @Autowired private MongoClient mongoClient; //TODO create bean
-    @Autowired private DatabasedMongoClient mongoDatabase; //TODO create bean
+    @Autowired private MongoClient mongoClient;
+    @Autowired private DatabasedMongoClient mongoDatabase;
     @Autowired private AdapterLog log;
     @Autowired private MessagingModule messagingModule;
 

--- a/src/main/java/org/atlasapi/persistence/MongoContentPersistenceModule.java
+++ b/src/main/java/org/atlasapi/persistence/MongoContentPersistenceModule.java
@@ -3,11 +3,13 @@ package org.atlasapi.persistence;
 import com.google.common.annotations.VisibleForTesting;
 import com.metabroadcast.common.ids.IdGenerator;
 import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
+import com.metabroadcast.common.persistence.mongo.DatabasedMongoClient;
 import com.metabroadcast.common.persistence.mongo.health.MongoIOProbe;
 import com.metabroadcast.common.properties.Configurer;
 import com.metabroadcast.common.properties.Parameter;
 import com.metabroadcast.common.queue.MessageSender;
 import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 import com.mongodb.ReadPreference;
 import org.atlasapi.media.channel.ChannelGroupStore;
 import org.atlasapi.media.channel.ServiceChannelStore;
@@ -74,6 +76,8 @@ public class MongoContentPersistenceModule implements ContentPersistenceModule {
     @Autowired private ReadPreference readPreference;
     @Autowired private Mongo mongo;
     @Autowired private DatabasedMongo db;
+    @Autowired private MongoClient mongoClient; //TODO create bean
+    @Autowired private DatabasedMongoClient mongoDatabase; //TODO create bean
     @Autowired private AdapterLog log;
     @Autowired private MessagingModule messagingModule;
 
@@ -125,8 +129,9 @@ public class MongoContentPersistenceModule implements ContentPersistenceModule {
 
     public ConstructorBasedMongoContentPersistenceModule persistenceModule() {
         return new ConstructorBasedMongoContentPersistenceModule(
-                mongo,
+                mongoClient,
                 db,
+                mongoDatabase,
                 messagingModule,
                 auditDbName,
                 log,

--- a/src/main/java/org/atlasapi/persistence/Transaction.java
+++ b/src/main/java/org/atlasapi/persistence/Transaction.java
@@ -1,0 +1,30 @@
+package org.atlasapi.persistence;
+
+import com.mongodb.client.ClientSession;
+
+import javax.annotation.Nullable;
+import java.io.Closeable;
+
+/**
+ * A layer of abstraction over a Mongo session to avoid having to expose the Mongo class as a return type
+ */
+public class Transaction implements Closeable {
+
+    @Nullable private final ClientSession session;
+
+    public Transaction(@Nullable ClientSession session) {
+        this.session = session;
+    }
+
+    @Nullable
+    public ClientSession getSession() {
+        return session;
+    }
+
+    @Override
+    public void close() {
+        if (session != null) {
+            session.close();
+        }
+    }
+}

--- a/src/main/java/org/atlasapi/persistence/Transaction.java
+++ b/src/main/java/org/atlasapi/persistence/Transaction.java
@@ -12,13 +12,29 @@ public class Transaction implements Closeable {
 
     @Nullable private final ClientSession session;
 
-    public Transaction(@Nullable ClientSession session) {
+    private Transaction(@Nullable ClientSession session) {
         this.session = session;
+    }
+
+    public static Transaction of(@Nullable ClientSession session) {
+        return new Transaction(session);
+    }
+
+
+    private static final Transaction NONE = new Transaction(null);
+    public static Transaction none() {
+        return NONE;
     }
 
     @Nullable
     public ClientSession getSession() {
         return session;
+    }
+
+    public void commit() {
+        if (session != null) {
+            session.commitTransaction();
+        }
     }
 
     @Override

--- a/src/main/java/org/atlasapi/persistence/lookup/InMemoryLookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/InMemoryLookupEntryStore.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Multimap;
 import com.metabroadcast.common.query.Selection;
 import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.persistence.Transaction;
 import org.atlasapi.persistence.content.listing.ContentListingProgress;
 import org.atlasapi.persistence.lookup.entry.LookupEntry;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
@@ -148,5 +149,25 @@ public class InMemoryLookupEntryStore implements LookupEntryStore {
     @Override
     public Iterable<LookupEntry> equivUpdatedSince(Publisher publisher, DateTime dateTime) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Transaction startTransaction() {
+        return null;
+    }
+
+    @Override
+    public void store(Transaction transaction, LookupEntry entry) {
+        store(entry);
+    }
+
+    @Override
+    public Iterable<LookupEntry> entriesForCanonicalUris(Transaction transaction, Iterable<String> uris) {
+        return entriesForCanonicalUris(uris);
+    }
+
+    @Override
+    public Iterable<LookupEntry> entriesForIds(Transaction transaction, Iterable<Long> ids) {
+        return entriesForIds(ids);
     }
 }

--- a/src/main/java/org/atlasapi/persistence/lookup/InMemoryLookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/InMemoryLookupEntryStore.java
@@ -153,7 +153,7 @@ public class InMemoryLookupEntryStore implements LookupEntryStore {
 
     @Override
     public Transaction startTransaction() {
-        return null;
+        return Transaction.none();
     }
 
     @Override

--- a/src/main/java/org/atlasapi/persistence/lookup/TransitiveLookupWriter.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/TransitiveLookupWriter.java
@@ -88,6 +88,7 @@ public class TransitiveLookupWriter implements LookupWriter {
         } catch (MongoCommandException e) {
             // The transaction was too large due to Mongo restrictions so we have to do it without a transaction
             if (e.getErrorCode() == 257 || e.getErrorCodeName().equals("TransactionTooLarge")) {
+                log.warn("Transaction for updating {} was too large, retrying without transactions", subjectUri);
                 LookupEntry subjectEntry = entryFor(null, subjectUri);
                 return writeLookup(null, subjectUri, subjectEntry, equivalentUris, sources);
             }

--- a/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
@@ -21,7 +21,7 @@ public interface LookupEntryStore {
      */
     void store(LookupEntry entry);
 
-    void store(@Nullable Transaction transaction, LookupEntry entry);
+    void store(Transaction transaction, LookupEntry entry);
 
     /**
      * Get entries for given URIs or Aliases. There is a one-to-many mapping
@@ -81,11 +81,11 @@ public interface LookupEntryStore {
      */
     Iterable<LookupEntry> entriesForCanonicalUris(Iterable<String> uris);
 
-    Iterable<LookupEntry> entriesForCanonicalUris(@Nullable Transaction transaction, Iterable<String> uris);
+    Iterable<LookupEntry> entriesForCanonicalUris(Transaction transaction, Iterable<String> uris);
 
     Iterable<LookupEntry> entriesForIds(Iterable<Long> ids);
 
-    Iterable<LookupEntry> entriesForIds(@Nullable Transaction transaction, Iterable<Long> ids);
+    Iterable<LookupEntry> entriesForIds(Transaction transaction, Iterable<Long> ids);
 
     Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers, Selection selection);
 

--- a/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
@@ -21,7 +21,7 @@ public interface LookupEntryStore {
      */
     void store(LookupEntry entry);
 
-    void store(Transaction transaction, LookupEntry entry);
+    void store(@Nullable Transaction transaction, LookupEntry entry);
 
     /**
      * Get entries for given URIs or Aliases. There is a one-to-many mapping
@@ -81,11 +81,11 @@ public interface LookupEntryStore {
      */
     Iterable<LookupEntry> entriesForCanonicalUris(Iterable<String> uris);
 
-    Iterable<LookupEntry> entriesForCanonicalUris(Transaction transaction, Iterable<String> uris);
+    Iterable<LookupEntry> entriesForCanonicalUris(@Nullable Transaction transaction, Iterable<String> uris);
 
     Iterable<LookupEntry> entriesForIds(Iterable<Long> ids);
 
-    Iterable<LookupEntry> entriesForIds(Transaction transaction, Iterable<Long> ids);
+    Iterable<LookupEntry> entriesForIds(@Nullable Transaction transaction, Iterable<Long> ids);
 
     Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers, Selection selection);
 

--- a/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/entry/LookupEntryStore.java
@@ -3,6 +3,7 @@ package org.atlasapi.persistence.lookup.entry;
 import com.google.common.base.Optional;
 import com.metabroadcast.common.query.Selection;
 import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.persistence.Transaction;
 import org.atlasapi.persistence.content.listing.ContentListingProgress;
 import org.joda.time.DateTime;
 
@@ -11,12 +12,16 @@ import java.util.Map;
 
 public interface LookupEntryStore {
 
+    Transaction startTransaction();
+
     /**
      * Stores specified entry, and all related entries (like those for aliases).
      * 
      * @param entry
      */
     void store(LookupEntry entry);
+
+    void store(Transaction transaction, LookupEntry entry);
 
     /**
      * Get entries for given URIs or Aliases. There is a one-to-many mapping
@@ -76,7 +81,11 @@ public interface LookupEntryStore {
      */
     Iterable<LookupEntry> entriesForCanonicalUris(Iterable<String> uris);
 
+    Iterable<LookupEntry> entriesForCanonicalUris(Transaction transaction, Iterable<String> uris);
+
     Iterable<LookupEntry> entriesForIds(Iterable<Long> ids);
+
+    Iterable<LookupEntry> entriesForIds(Transaction transaction, Iterable<Long> ids);
 
     Iterable<LookupEntry> entriesForPublishers(Iterable<Publisher> publishers, Selection selection);
 

--- a/src/main/java/org/atlasapi/persistence/lookup/mongo/MongoLookupEntryStore.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/mongo/MongoLookupEntryStore.java
@@ -120,7 +120,7 @@ public class MongoLookupEntryStore implements LookupEntryStore, NewLookupWriter 
     public Transaction startTransaction() {
         try {
             ClientSession session = mongo.getMongoClient().startSession();
-            session.startTransaction(); //TODO: options?
+            session.startTransaction();
             return new Transaction(session);
         } catch (MongoClientException e) {
             log.error(

--- a/src/test/java/org/atlasapi/persistence/ConstructorBasedMongoContentPersistenceModuleIT.java
+++ b/src/test/java/org/atlasapi/persistence/ConstructorBasedMongoContentPersistenceModuleIT.java
@@ -1,9 +1,23 @@
 package org.atlasapi.persistence;
 
-import java.util.Map;
-
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.metabroadcast.applications.client.model.internal.Application;
-import org.atlasapi.application.v3.DefaultApplication;
+import com.metabroadcast.common.base.Maybe;
+import com.metabroadcast.common.persistence.MongoTestHelper;
+import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
+import com.metabroadcast.common.persistence.mongo.DatabasedMongoClient;
+import com.metabroadcast.common.properties.Parameter;
+import com.metabroadcast.common.queue.Message;
+import com.metabroadcast.common.queue.MessageConsumerFactory;
+import com.metabroadcast.common.queue.MessageSender;
+import com.metabroadcast.common.queue.MessageSenderFactory;
+import com.metabroadcast.common.queue.MessageSerializer;
+import com.metabroadcast.common.queue.MessagingException;
+import com.mongodb.MongoClient;
+import com.mongodb.ReadPreference;
 import org.atlasapi.media.channel.Channel;
 import org.atlasapi.media.channel.ChannelGroup;
 import org.atlasapi.media.channel.ChannelGroupStore;
@@ -42,27 +56,11 @@ import org.atlasapi.persistence.logging.MongoLoggingAdapter;
 import org.atlasapi.persistence.lookup.entry.LookupEntry;
 import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 import org.atlasapi.persistence.topic.TopicStore;
-
-import com.metabroadcast.common.base.Maybe;
-import com.metabroadcast.common.persistence.MongoTestHelper;
-import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
-import com.metabroadcast.common.properties.Parameter;
-import com.metabroadcast.common.queue.Message;
-import com.metabroadcast.common.queue.MessageConsumerFactory;
-import com.metabroadcast.common.queue.MessageSender;
-import com.metabroadcast.common.queue.MessageSenderFactory;
-import com.metabroadcast.common.queue.MessageSerializer;
-import com.metabroadcast.common.queue.MessagingException;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.mongodb.Mongo;
-import com.mongodb.ReadPreference;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -73,8 +71,11 @@ import static org.mockito.Mockito.mock;
 
 public class ConstructorBasedMongoContentPersistenceModuleIT {
 
-    private final Mongo mongo = MongoTestHelper.anEmptyMongo();
+
+    private final MongoClient mongo = MongoTestHelper.anEmptyMongo();
     private final DatabasedMongo db = new DatabasedMongo(mongo, "atlas");
+    private final DatabasedMongoClient mongoDatabase = new DatabasedMongoClient(mongo, "atlas");
+
     private final MongoLoggingAdapter adapterLog = new MongoLoggingAdapter(db);
     private final MessagingModule messagingModule = new MessagingModule(){
         @Override
@@ -119,6 +120,7 @@ public class ConstructorBasedMongoContentPersistenceModuleIT {
         module = new ConstructorBasedMongoContentPersistenceModule(
                 mongo,
                 db,
+                mongoDatabase,
                 messagingModule,
                 "atlas-audit",
                 adapterLog,
@@ -138,6 +140,7 @@ public class ConstructorBasedMongoContentPersistenceModuleIT {
         moduleWithProcessingConfigTrue = new ConstructorBasedMongoContentPersistenceModule(
                 mongo,
                 db,
+                mongoDatabase,
                 messagingModule,
                 "atlas-audit",
                 adapterLog,

--- a/src/test/java/org/atlasapi/persistence/content/mongo/MongoContentListerTest.java
+++ b/src/test/java/org/atlasapi/persistence/content/mongo/MongoContentListerTest.java
@@ -1,28 +1,24 @@
 package org.atlasapi.persistence.content.mongo;
 
-import static org.atlasapi.media.entity.Publisher.BBC;
-import static org.atlasapi.media.entity.Publisher.C4;
-import static org.atlasapi.persistence.content.ContentCategory.CONTAINER;
-import static org.atlasapi.persistence.content.ContentCategory.TOP_LEVEL_ITEM;
-import static org.atlasapi.persistence.content.listing.ContentListingCriteria.defaultCriteria;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-
-import java.util.Arrays;
-import java.util.List;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.metabroadcast.applications.client.model.internal.Application;
+import com.metabroadcast.common.persistence.MongoTestHelper;
+import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
+import com.metabroadcast.common.persistence.mongo.DatabasedMongoClient;
 import com.metabroadcast.common.query.Selection;
+import com.metabroadcast.common.time.DateTimeZones;
+import com.metabroadcast.common.time.SystemClock;
+import com.mongodb.DBObject;
+import com.mongodb.MongoClient;
+import com.mongodb.ReadPreference;
 import org.atlasapi.content.criteria.ContentQuery;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Content;
 import org.atlasapi.media.entity.EventRef;
-import org.atlasapi.media.entity.TopicRef;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.media.entity.TopicRef;
 import org.atlasapi.persistence.audit.PerHourAndDayMongoPersistenceAuditLog;
 import org.atlasapi.persistence.audit.PersistenceAuditLog;
 import org.atlasapi.persistence.content.listing.ContentListingProgress;
@@ -36,13 +32,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.metabroadcast.common.persistence.MongoTestHelper;
-import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
-import com.metabroadcast.common.time.DateTimeZones;
-import com.metabroadcast.common.time.SystemClock;
-import com.mongodb.ReadPreference;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.atlasapi.media.entity.Publisher.BBC;
+import static org.atlasapi.media.entity.Publisher.C4;
+import static org.atlasapi.persistence.content.ContentCategory.CONTAINER;
+import static org.atlasapi.persistence.content.ContentCategory.TOP_LEVEL_ITEM;
+import static org.atlasapi.persistence.content.listing.ContentListingCriteria.defaultCriteria;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 @RunWith( MockitoJUnitRunner.class )
 public class MongoContentListerTest {
@@ -54,12 +56,18 @@ public class MongoContentListerTest {
     private static final Brand bbcBrand= new Brand("bbcBrand1", "bbcBrand1curie", Publisher.BBC);
     private static final Brand c4Brand= new Brand("c4Brand1", "c4Brand1curie", Publisher.C4);
 
-    private static final DatabasedMongo mongo = MongoTestHelper.anEmptyTestDatabase();
+    private static final MongoClient mongoClient = MongoTestHelper.anEmptyMongo();
+    private static final DatabasedMongo mongo = new DatabasedMongo(mongoClient, "testing");
+    private static final DatabasedMongoClient mongoDatabase = new DatabasedMongoClient(mongoClient, "testing");
     private static final PersistenceAuditLog persistenceAuditLog = new PerHourAndDayMongoPersistenceAuditLog(mongo);
     
     private final MongoContentLister lister = new MongoContentLister(mongo, 
             new MongoContentResolver(mongo, new MongoLookupEntryStore(
-                    mongo.collection("lookup"), persistenceAuditLog, ReadPreference.primary())));
+                    mongoDatabase.collection("lookup", DBObject.class),
+                    mongoDatabase,
+                    persistenceAuditLog,
+                    ReadPreference.primary()))
+    );
 
     private static final ServiceResolver serviceResolver = mock(ServiceResolver.class);
     private static final PlayerResolver playerResolver = mock(PlayerResolver.class);

--- a/src/test/java/org/atlasapi/persistence/content/mongo/MongoContentListerTest.java
+++ b/src/test/java/org/atlasapi/persistence/content/mongo/MongoContentListerTest.java
@@ -9,7 +9,6 @@ import com.metabroadcast.common.persistence.mongo.DatabasedMongoClient;
 import com.metabroadcast.common.query.Selection;
 import com.metabroadcast.common.time.DateTimeZones;
 import com.metabroadcast.common.time.SystemClock;
-import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.ReadPreference;
 import org.atlasapi.content.criteria.ContentQuery;
@@ -63,8 +62,8 @@ public class MongoContentListerTest {
     
     private final MongoContentLister lister = new MongoContentLister(mongo, 
             new MongoContentResolver(mongo, new MongoLookupEntryStore(
-                    mongoDatabase.collection("lookup", DBObject.class),
                     mongoDatabase,
+                    "lookup",
                     persistenceAuditLog,
                     ReadPreference.primary()))
     );

--- a/src/test/java/org/atlasapi/persistence/content/mongo/MongoContentPurgerTest.java
+++ b/src/test/java/org/atlasapi/persistence/content/mongo/MongoContentPurgerTest.java
@@ -10,7 +10,6 @@ import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
 import com.metabroadcast.common.persistence.mongo.DatabasedMongoClient;
 import com.metabroadcast.common.time.SystemClock;
 import com.mongodb.DBCollection;
-import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.ReadPreference;
 import org.atlasapi.media.entity.Alias;
@@ -68,8 +67,8 @@ public class MongoContentPurgerTest {
         persistenceAuditLog = new PerHourAndDayMongoPersistenceAuditLog(db);
         DBCollection lookupCollection = db.collection("lookup");
         entryStore = new MongoLookupEntryStore(
-                mongoDatabase.collection("lookup", DBObject.class),
                 mongoDatabase,
+                "lookup",
                 new NoLoggingPersistenceAuditLog(),
                 ReadPreference.primary()
         );

--- a/src/test/java/org/atlasapi/persistence/content/mongo/MongoPersonStoreTest.java
+++ b/src/test/java/org/atlasapi/persistence/content/mongo/MongoPersonStoreTest.java
@@ -9,7 +9,6 @@ import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
 import com.metabroadcast.common.persistence.mongo.DatabasedMongoClient;
 import com.metabroadcast.common.text.NumberPadder;
 import com.metabroadcast.common.time.SystemClock;
-import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.ReadPreference;
 import org.atlasapi.media.entity.ChildRef;
@@ -67,8 +66,8 @@ public class MongoPersonStoreTest {
         mongoDatabase = new DatabasedMongoClient(mongo, "testing");
         persistenceAuditLog = new PerHourAndDayMongoPersistenceAuditLog(db);
         entryStore = new MongoLookupEntryStore(
-                mongoDatabase.collection("peopleLookup", DBObject.class),
                 mongoDatabase,
+                "peopleLookup",
                 new NoLoggingPersistenceAuditLog(),
                 ReadPreference.primary()
         );

--- a/src/test/java/org/atlasapi/persistence/content/organisation/MongoOrganisationStoreTest.java
+++ b/src/test/java/org/atlasapi/persistence/content/organisation/MongoOrganisationStoreTest.java
@@ -1,10 +1,15 @@
 package org.atlasapi.persistence.content.organisation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.util.List;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.metabroadcast.common.persistence.MongoTestHelper;
+import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
+import com.metabroadcast.common.persistence.mongo.DatabasedMongoClient;
+import com.mongodb.DBObject;
+import com.mongodb.MongoClient;
+import com.mongodb.ReadPreference;
 import org.atlasapi.media.entity.ChildRef;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Organisation;
@@ -18,18 +23,17 @@ import org.atlasapi.persistence.lookup.mongo.MongoLookupEntryStore;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.metabroadcast.common.persistence.MongoTestHelper;
-import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
-import com.mongodb.ReadPreference;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 
 public class MongoOrganisationStoreTest {
 
+        private MongoClient mongoClient;
         private DatabasedMongo db;
+        private DatabasedMongoClient mongoDatabase;
         private MongoOrganisationStore store;
         private MongoLookupEntryStore entryStore;
         private PersistenceAuditLog persistenceAuditLog;
@@ -38,10 +42,16 @@ public class MongoOrganisationStoreTest {
         
         @Before
         public void setUp() {
-            db = MongoTestHelper.anEmptyTestDatabase();
+            mongoClient = MongoTestHelper.anEmptyMongo();
+            db = new DatabasedMongo(mongoClient, "testing");
+            mongoDatabase = new DatabasedMongoClient(mongoClient, "testing");
             persistenceAuditLog = new PerHourAndDayMongoPersistenceAuditLog(db);
-            entryStore = new MongoLookupEntryStore(db.collection("peopleLookup"), new NoLoggingPersistenceAuditLog(), 
-                    ReadPreference.primary());
+            entryStore = new MongoLookupEntryStore(
+                    mongoDatabase.collection("peopleLookup", DBObject.class),
+                    mongoDatabase,
+                    new NoLoggingPersistenceAuditLog(),
+                    ReadPreference.primary()
+            );
             store = new MongoOrganisationStore(db, TransitiveLookupWriter.explicitTransitiveLookupWriter(entryStore), 
                     entryStore, persistenceAuditLog);
         }

--- a/src/test/java/org/atlasapi/persistence/content/organisation/MongoOrganisationStoreTest.java
+++ b/src/test/java/org/atlasapi/persistence/content/organisation/MongoOrganisationStoreTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.Lists;
 import com.metabroadcast.common.persistence.MongoTestHelper;
 import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
 import com.metabroadcast.common.persistence.mongo.DatabasedMongoClient;
-import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.ReadPreference;
 import org.atlasapi.media.entity.ChildRef;
@@ -47,8 +46,8 @@ public class MongoOrganisationStoreTest {
             mongoDatabase = new DatabasedMongoClient(mongoClient, "testing");
             persistenceAuditLog = new PerHourAndDayMongoPersistenceAuditLog(db);
             entryStore = new MongoLookupEntryStore(
-                    mongoDatabase.collection("peopleLookup", DBObject.class),
                     mongoDatabase,
+                    "peopleLookup",
                     new NoLoggingPersistenceAuditLog(),
                     ReadPreference.primary()
             );

--- a/src/test/java/org/atlasapi/persistence/lookup/TransitiveLookupWriterTest.java
+++ b/src/test/java/org/atlasapi/persistence/lookup/TransitiveLookupWriterTest.java
@@ -40,6 +40,7 @@ import static org.atlasapi.persistence.lookup.entry.LookupEntry.lookupEntryFrom;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.iterableWithSize;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -348,15 +349,15 @@ public class TransitiveLookupWriterTest extends TestCase {
         LookupEntry paLookupEntry = lookupEntryFrom(paItem).copyWithDirectEquivalents(EquivRefs.of(LookupRef.from(pnItem), OUTGOING));
         LookupEntry pnLookupEntry = lookupEntryFrom(pnItem).copyWithDirectEquivalents(EquivRefs.of(LookupRef.from(paItem), OUTGOING));
         
-        when(store.entriesForCanonicalUris(ImmutableSet.of(pnItem.getCanonicalUri(), paItem.getCanonicalUri())))
+        when(store.entriesForCanonicalUris(null, ImmutableSet.of(pnItem.getCanonicalUri(), paItem.getCanonicalUri())))
             .thenReturn(ImmutableList.of(paLookupEntry, pnLookupEntry));
-        when(store.entriesForCanonicalUris(ImmutableList.of(paItem.getCanonicalUri())))
+        when(store.entriesForCanonicalUris(null, ImmutableList.of(paItem.getCanonicalUri())))
             .thenReturn(ImmutableList.of(paLookupEntry));
         
         writer.writeLookup(ContentRef.valueOf(paItem), ImmutableSet.of(ContentRef.valueOf(pnItem)), ImmutableSet.of(Publisher.PA, Publisher.PREVIEW_NETWORKS));
         
-        verify(store).entriesForCanonicalUris(ImmutableSet.of(pnItem.getCanonicalUri(), paItem.getCanonicalUri()));
-        verify(store, times(2)).entriesForCanonicalUris(ImmutableList.of(paItem.getCanonicalUri()));
+        verify(store).entriesForCanonicalUris(null, ImmutableSet.of(pnItem.getCanonicalUri(), paItem.getCanonicalUri()));
+        verify(store, times(2)).entriesForCanonicalUris(null, ImmutableList.of(paItem.getCanonicalUri()));
         verify(store, never()).store(Mockito.isA(LookupEntry.class));
         
         Mockito.validateMockitoUsage();
@@ -441,14 +442,14 @@ public class TransitiveLookupWriterTest extends TestCase {
         
         bigEntry = bigEntry.copyWithEquivalents(equivs);
         
-        when(store.entriesForCanonicalUris(argThat(hasItems(big.getCanonicalUri(), equiv.getCanonicalUri()))))
+        when(store.entriesForCanonicalUris(any(), argThat(hasItems(big.getCanonicalUri(), equiv.getCanonicalUri()))))
             .thenReturn(ImmutableList.of(bigEntry, equivEntry));
-        when(store.entriesForCanonicalUris(ImmutableList.of(equiv.getCanonicalUri())))
+        when(store.entriesForCanonicalUris(null, ImmutableList.of(equiv.getCanonicalUri())))
                 .thenReturn(ImmutableList.of(equivEntry));
         
         writeLookup(writer, equiv, ImmutableSet.of(big), Publisher.all());
         
-        verify(store).entriesForCanonicalUris(argThat(hasItems(big.getCanonicalUri(), equiv.getCanonicalUri())));
+        verify(store).entriesForCanonicalUris(any(), argThat(hasItems(big.getCanonicalUri(), equiv.getCanonicalUri())));
         verify(store, never()).store(Mockito.isA(LookupEntry.class));
         
         Mockito.validateMockitoUsage();
@@ -494,26 +495,26 @@ public class TransitiveLookupWriterTest extends TestCase {
         ImmutableSet<LookupEntry> directSubsetEntries = directSubsetEntriesBuilder.build();
         ImmutableSet<LookupEntry> directEntries = MoreSets.add(directSubsetEntries, otherEntry);
 
-        when(store.entriesForCanonicalUris(ImmutableList.of(equiv.getCanonicalUri())))
+        when(store.entriesForCanonicalUris(null, ImmutableList.of(equiv.getCanonicalUri())))
                 .thenReturn(ImmutableList.of(equivEntry));
-        when(store.entriesForCanonicalUris(argThat(iterableWithSize(directEquivSubsetUris.size() + 1))))
+        when(store.entriesForCanonicalUris(any(), argThat(iterableWithSize(directEquivSubsetUris.size() + 1))))
                 .thenReturn(MoreSets.add(directSubsetEntries, equivEntry));
-        when(store.entriesForCanonicalUris(argThat(iterableWithSize(directEquivUris.size() + 1))))
+        when(store.entriesForCanonicalUris(any(), argThat(iterableWithSize(directEquivUris.size() + 1))))
                 .thenReturn(MoreSets.add(directEntries, equivEntry));
-        when(store.entriesForCanonicalUris(argThat(iterableWithSize(greaterThan(directEquivUris.size() + 1)))))
+        when(store.entriesForCanonicalUris(any(), argThat(iterableWithSize(greaterThan(directEquivUris.size() + 1)))))
                 .thenReturn(MoreSets.add(directEntries, equivEntry));
 
         Optional<Set<LookupEntry>> result = writer.writeLookup(equiv.getCanonicalUri(), directEquivUris, Publisher.all());
 
         //One time attempting to update direct subset
         verify(store, times(1))
-                .entriesForCanonicalUris(argThat(iterableWithSize(directEquivSubsetUris.size() + 1)));
+                .entriesForCanonicalUris(any(), argThat(iterableWithSize(directEquivSubsetUris.size() + 1)));
         //One time attempting to update entire direct set
         verify(store, times(1))
-                .entriesForCanonicalUris(argThat(iterableWithSize(directEquivUris.size() + 1)));
+                .entriesForCanonicalUris(any(), argThat(iterableWithSize(directEquivUris.size() + 1)));
         //One time to update direct subset (and not entire direct set)
         verify(store, times(1))
-                .entriesForCanonicalUris(argThat(iterableWithSize(greaterThan(directEquivUris.size() + 1))));
+                .entriesForCanonicalUris(any(), argThat(iterableWithSize(greaterThan(directEquivUris.size() + 1))));
 
         assertTrue(!result.isPresent());
 

--- a/src/test/java/org/atlasapi/persistence/lookup/mongo/MongoLookupEntryStoreTest.java
+++ b/src/test/java/org/atlasapi/persistence/lookup/mongo/MongoLookupEntryStoreTest.java
@@ -66,8 +66,8 @@ public class MongoLookupEntryStoreTest {
         mongo = MongoTestHelper.anEmptyTestDatabaseWithMongoClient();
         collection = mongo.collection("lookup", DBObject.class);
         entryStore = new MongoLookupEntryStore(
-                collection,
                 mongo,
+                "lookup",
                 ReadPreference.primary(),
                 new NoLoggingPersistenceAuditLog(),
                 log

--- a/src/test/java/org/atlasapi/persistence/output/MongoAvailableItemsResolverTest.java
+++ b/src/test/java/org/atlasapi/persistence/output/MongoAvailableItemsResolverTest.java
@@ -7,8 +7,11 @@ import com.metabroadcast.applications.client.model.internal.Application;
 import com.metabroadcast.applications.client.model.internal.ApplicationConfiguration;
 import com.metabroadcast.common.persistence.MongoTestHelper;
 import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
+import com.metabroadcast.common.persistence.mongo.DatabasedMongoClient;
 import com.metabroadcast.common.time.DateTimeZones;
 import com.metabroadcast.common.time.TimeMachine;
+import com.mongodb.DBObject;
+import com.mongodb.MongoClient;
 import com.mongodb.ReadPreference;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.ChildRef;
@@ -50,16 +53,22 @@ public class MongoAvailableItemsResolverTest {
     
     private static final ServiceResolver serviceResolver = mock(ServiceResolver.class);
     private static final PlayerResolver playerResolver = mock(PlayerResolver.class);
-    
-    private final DatabasedMongo mongo = MongoTestHelper.anEmptyTestDatabase();
+
+    private final MongoClient mongoClient = MongoTestHelper.anEmptyMongo();
+    private final DatabasedMongo db = new DatabasedMongo(mongoClient, "testing");
+    private final DatabasedMongoClient mongoDatabase = new DatabasedMongoClient(mongoClient, "testing");
     private final TimeMachine clock = new TimeMachine();
     private final MongoLookupEntryStore lookupStore
-        = new MongoLookupEntryStore(mongo.collection("lookup"), 
-                new NoLoggingPersistenceAuditLog(), ReadPreference.primary());
+        = new MongoLookupEntryStore(
+                mongoDatabase.collection("lookup", DBObject.class),
+                mongoDatabase,
+                new NoLoggingPersistenceAuditLog(),
+            ReadPreference.primary()
+    );
     private final MongoAvailableItemsResolver resolver
-        = new MongoAvailableItemsResolver(mongo, lookupStore, clock);
-    private final PersistenceAuditLog persistenceAuditLog = new PerHourAndDayMongoPersistenceAuditLog(mongo);
-    private final ContentWriter writer = new MongoContentWriter(mongo, lookupStore, persistenceAuditLog, 
+        = new MongoAvailableItemsResolver(db, lookupStore, clock);
+    private final PersistenceAuditLog persistenceAuditLog = new PerHourAndDayMongoPersistenceAuditLog(db);
+    private final ContentWriter writer = new MongoContentWriter(db, lookupStore, persistenceAuditLog,
             playerResolver, serviceResolver, clock);
     
     private final Brand primary = new Brand("primary", "primary", Publisher.BBC);

--- a/src/test/java/org/atlasapi/persistence/output/MongoAvailableItemsResolverTest.java
+++ b/src/test/java/org/atlasapi/persistence/output/MongoAvailableItemsResolverTest.java
@@ -10,7 +10,6 @@ import com.metabroadcast.common.persistence.mongo.DatabasedMongo;
 import com.metabroadcast.common.persistence.mongo.DatabasedMongoClient;
 import com.metabroadcast.common.time.DateTimeZones;
 import com.metabroadcast.common.time.TimeMachine;
-import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.ReadPreference;
 import org.atlasapi.media.entity.Brand;
@@ -60,9 +59,9 @@ public class MongoAvailableItemsResolverTest {
     private final TimeMachine clock = new TimeMachine();
     private final MongoLookupEntryStore lookupStore
         = new MongoLookupEntryStore(
-                mongoDatabase.collection("lookup", DBObject.class),
                 mongoDatabase,
-                new NoLoggingPersistenceAuditLog(),
+            "lookup",
+            new NoLoggingPersistenceAuditLog(),
             ReadPreference.primary()
     );
     private final MongoAvailableItemsResolver resolver


### PR DESCRIPTION
Prevent race conditions when updating equiv sets in the TransitiveLookupWriter by using Mongo transactions to update all lookup entries as a single operation. The update will fail and retry if any entry that will be updated in the transaction is also modified by another process in the meantime.

As of Mongo 4.0 there is a size restriction on how large a transaction can be; if this occurs the update will be retried without using a transaction.

New Mongo driver classes supporting transactions have been added to the MongoLookupEntryStore to support this.