### PR TITLE
Move equiv messaging to lookup writer (ENG-757)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-persistence</artifactId>
-    <version>5.1-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
     <build>
         <finalName>atlas-persistence</finalName>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-persistence</artifactId>
-    <version>5.0-SNAPSHOT</version>
+    <version>5.1-SNAPSHOT</version>
     <build>
         <finalName>atlas-persistence</finalName>
         <plugins>

--- a/src/main/java/org/atlasapi/messaging/v3/ContentEquivalenceAssertionMessenger.java
+++ b/src/main/java/org/atlasapi/messaging/v3/ContentEquivalenceAssertionMessenger.java
@@ -1,28 +1,30 @@
 package org.atlasapi.messaging.v3;
 
-import java.math.BigInteger;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
-import org.atlasapi.media.entity.Content;
-import org.atlasapi.media.entity.LookupRef;
-import org.atlasapi.persistence.lookup.entry.LookupEntry;
-import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Longs;
 import com.metabroadcast.common.ids.NumberToShortStringCodec;
 import com.metabroadcast.common.ids.SubstitutionTableNumberCodec;
 import com.metabroadcast.common.queue.MessageSender;
 import com.metabroadcast.common.stream.MoreCollectors;
 import com.metabroadcast.common.time.Timestamp;
 import com.metabroadcast.common.time.Timestamper;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.primitives.Longs;
+import org.atlasapi.media.entity.Content;
+import org.atlasapi.media.entity.Identified;
+import org.atlasapi.media.entity.LookupRef;
+import org.atlasapi.persistence.content.KnownTypeContentResolver;
+import org.atlasapi.persistence.lookup.entry.LookupEntry;
+import org.atlasapi.persistence.lookup.entry.LookupEntryStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -34,25 +36,70 @@ public class ContentEquivalenceAssertionMessenger {
     private final MessageSender<ContentEquivalenceAssertionMessage> sender;
     private final Timestamper timestamper;
     private final LookupEntryStore lookupEntryStore;
+    private final KnownTypeContentResolver contentResolver;
     private final NumberToShortStringCodec entityIdCodec;
 
     private ContentEquivalenceAssertionMessenger(
             MessageSender<ContentEquivalenceAssertionMessage> sender,
             Timestamper timestamper,
-            LookupEntryStore lookupEntryStore
+            LookupEntryStore lookupEntryStore,
+            KnownTypeContentResolver contentResolver
     ) {
         this.sender = checkNotNull(sender);
         this.timestamper = checkNotNull(timestamper);
         this.lookupEntryStore = checkNotNull(lookupEntryStore);
+        this.contentResolver = checkNotNull(contentResolver);
         this.entityIdCodec = SubstitutionTableNumberCodec.lowerCaseOnly();
     }
 
     public static ContentEquivalenceAssertionMessenger create(
             MessageSender<ContentEquivalenceAssertionMessage> sender,
             Timestamper timestamper,
-            LookupEntryStore lookupEntryStore
+            LookupEntryStore lookupEntryStore,
+            KnownTypeContentResolver contentResolver
     ) {
-        return new ContentEquivalenceAssertionMessenger(sender, timestamper, lookupEntryStore);
+        return new ContentEquivalenceAssertionMessenger(sender, timestamper, lookupEntryStore, contentResolver);
+    }
+
+    public void sendMessage(
+            LookupEntry subject,
+            Collection<LookupRef> adjacents,
+            Set<String> sources
+    ) {
+        try {
+            Identified subjectContent = contentResolver.findByLookupRefs(ImmutableList.of(subject.lookupRef()))
+                    .getFirstValue()
+                    .requireValue();
+
+            if (!(subjectContent instanceof Content)) {
+                throw new IllegalArgumentException(subject + " is not a piece of content");
+            }
+
+            ImmutableList<Content> adjacentContent = contentResolver.findByLookupRefs(adjacents)
+                    .getAllResolvedResults()
+                    .stream()
+                    .filter(Content.class::isInstance)
+                    .map(Content.class::cast)
+                    .collect(MoreCollectors.toImmutableList());
+
+            if (adjacentContent.size() != adjacents.size()) {
+                log.warn("Not all adjacents for {} were successfully resolved", subject);
+            }
+
+            ContentEquivalenceAssertionMessage message = messageFrom(
+                    (Content) subjectContent,
+                    adjacentContent,
+                    ImmutableSet.copyOf(sources)
+            );
+
+            sender.sendMessage(
+                    message,
+                    getMessagePartitionKey(subject)
+            );
+
+        } catch (Exception e) {
+            log.error("Failed to send equiv update message: " + subject, e);
+        }
     }
 
     public void sendMessage(
@@ -127,28 +174,34 @@ public class ContentEquivalenceAssertionMessenger {
                 .findFirst();
 
         if (lookupEntryOptional.isPresent()) {
-            LookupEntry lookupEntry = lookupEntryOptional.get();
-
-            // Given most of the time the equivalence results do not change the existing graph
-            // (due to the fact that we are often rerunning equivalence on the same items with
-            // the same results) the underlying graph will remain unchanged. Therefore if we get
-            // the smallest lookup entry ID from that graph that ID should be consistent enough
-            // to use as a partition key and ensure updates on the same graph end up on the same
-            // partition.
-            Optional<Long> graphId = Stream.concat(
-                    lookupEntry.equivalents().stream(),
-                    lookupEntry.getNeighbours().stream()
-            )
-                    .map(LookupRef::id)
-                    .sorted()
-                    .findFirst();
-
-            if (graphId.isPresent()) {
-                return Longs.toByteArray(graphId.get());
-            }
+            return getMessagePartitionKey(lookupEntryOptional.get());
         }
 
         // Default to returning the subject ID as the partition key
         return Longs.toByteArray(subject.getId());
+    }
+
+    private byte[] getMessagePartitionKey(LookupEntry lookupEntry) {
+
+        // Given most of the time the equivalence results do not change the existing graph
+        // (due to the fact that we are often rerunning equivalence on the same items with
+        // the same results) the underlying graph will remain unchanged. Therefore if we get
+        // the smallest lookup entry ID from that graph that ID should be consistent enough
+        // to use as a partition key and ensure updates on the same graph end up on the same
+        // partition.
+        Optional<Long> graphId = Stream.concat(
+                lookupEntry.equivalents().stream(),
+                lookupEntry.getNeighbours().stream()
+        )
+                .map(LookupRef::id)
+                .sorted()
+                .findFirst();
+
+        if (graphId.isPresent()) {
+            return Longs.toByteArray(graphId.get());
+        }
+
+        // Default to returning the subject ID as the partition key
+        return Longs.toByteArray(lookupEntry.id());
     }
 }

--- a/src/main/java/org/atlasapi/persistence/ConstructorBasedMongoContentPersistenceModule.java
+++ b/src/main/java/org/atlasapi/persistence/ConstructorBasedMongoContentPersistenceModule.java
@@ -50,6 +50,8 @@ import org.atlasapi.persistence.content.IdSettingContentWriter;
 import org.atlasapi.persistence.content.KnownTypeContentResolver;
 import org.atlasapi.persistence.content.LookupBackedContentIdGenerator;
 import org.atlasapi.persistence.content.LookupResolvingContentResolver;
+import org.atlasapi.persistence.content.MessageQueueingContentWriter;
+import org.atlasapi.persistence.content.MessageQueueingEquivalenceContentWriter;
 import org.atlasapi.persistence.content.MessageQueuingContentGroupWriter;
 import org.atlasapi.persistence.content.PeopleQueryResolver;
 import org.atlasapi.persistence.content.listing.MongoProgressStore;
@@ -256,6 +258,14 @@ public class ConstructorBasedMongoContentPersistenceModule implements ContentPer
 
         contentWriter = new EquivalenceWritingContentWriter(contentWriter, explicitLookupWriter());
 
+        if (messagingEnabled) {
+            contentWriter = new MessageQueueingContentWriter(
+                    contentChanges(),
+                    contentWriter,
+                    contentResolver()
+            );
+        }
+
         contentWriter = new IdSettingContentWriter(
                 contentWriter, lookupBackedContentIdGenerator()
         );
@@ -274,6 +284,14 @@ public class ConstructorBasedMongoContentPersistenceModule implements ContentPer
                 contentWriter, lookupBackedContentIdGenerator()
         );
 
+        if (messagingEnabled) {
+            contentWriter = new MessageQueueingContentWriter(
+                    contentChanges(),
+                    contentWriter,
+                    contentResolver()
+            );
+        }
+
         return contentWriter;
     }
 
@@ -285,6 +303,14 @@ public class ConstructorBasedMongoContentPersistenceModule implements ContentPer
         );
 
         EquivalenceContentWriter equivalenceContentWriter = new EquivalenceWritingContentWriter(contentWriter, explicitLookupWriter());
+
+        if (messagingEnabled) {
+            equivalenceContentWriter = new MessageQueueingEquivalenceContentWriter(
+                    contentChanges(),
+                    equivalenceContentWriter,
+                    contentResolver()
+            );
+        }
 
         return equivalenceContentWriter;
     }

--- a/src/main/java/org/atlasapi/persistence/ConstructorBasedMongoContentPersistenceModule.java
+++ b/src/main/java/org/atlasapi/persistence/ConstructorBasedMongoContentPersistenceModule.java
@@ -280,10 +280,6 @@ public class ConstructorBasedMongoContentPersistenceModule implements ContentPer
                 playerResolver(), serviceResolver(), new SystemClock()
         );
 
-        contentWriter = new IdSettingContentWriter(
-                contentWriter, lookupBackedContentIdGenerator()
-        );
-
         if (messagingEnabled) {
             contentWriter = new MessageQueueingContentWriter(
                     contentChanges(),
@@ -291,6 +287,10 @@ public class ConstructorBasedMongoContentPersistenceModule implements ContentPer
                     contentResolver()
             );
         }
+
+        contentWriter = new IdSettingContentWriter(
+                contentWriter, lookupBackedContentIdGenerator()
+        );
 
         return contentWriter;
     }

--- a/src/main/java/org/atlasapi/persistence/content/MessageQueueingEquivalenceContentWriter.java
+++ b/src/main/java/org/atlasapi/persistence/content/MessageQueueingEquivalenceContentWriter.java
@@ -6,7 +6,6 @@ import com.metabroadcast.common.time.Timestamper;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Item;
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.messaging.v3.ContentEquivalenceAssertionMessenger;
 import org.atlasapi.messaging.v3.EntityUpdatedMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,23 +27,20 @@ public class MessageQueueingEquivalenceContentWriter extends MessageQueueingCont
     private final EquivalenceContentWriter equivalenceContentWriter;
 
     public MessageQueueingEquivalenceContentWriter(
-            ContentEquivalenceAssertionMessenger messenger,
             MessageSender<EntityUpdatedMessage> sender,
             EquivalenceContentWriter equivalenceContentWriter,
             ContentResolver contentResolver
     ) {
-        this(messenger, sender, equivalenceContentWriter, contentResolver, new SystemClock());
+        this(sender, equivalenceContentWriter, contentResolver, new SystemClock());
     }
 
     public MessageQueueingEquivalenceContentWriter(
-            ContentEquivalenceAssertionMessenger messenger,
             MessageSender<EntityUpdatedMessage> sender,
             EquivalenceContentWriter equivalenceContentWriter,
             ContentResolver contentResolver,
             Timestamper clock
     ) {
         super(
-                messenger,
                 sender,
                 equivalenceContentWriter,
                 contentResolver,

--- a/src/main/java/org/atlasapi/persistence/lookup/TransitiveLookupWriter.java
+++ b/src/main/java/org/atlasapi/persistence/lookup/TransitiveLookupWriter.java
@@ -39,6 +39,9 @@ public class TransitiveLookupWriter implements LookupWriter {
     private static final Logger timerLog = LoggerFactory.getLogger("TIMER");
     private static final int maxSetSize = 150;
     private static final int WRITE_RETRIES = 5;
+    private static final Set<String> ALL_PUBLISHER_KEYS = Publisher.all().stream()
+            .map(Publisher::key)
+            .collect(MoreCollectors.toImmutableSet());
 
     private final LookupEntryStore entryStore;
     private final boolean explicit;
@@ -337,7 +340,7 @@ public class TransitiveLookupWriter implements LookupWriter {
         messenger.sendMessage(
                 entry,
                 entry.getOutgoing(),
-                Publisher.all().stream().map(Publisher::key).collect(MoreCollectors.toImmutableSet())
+                ALL_PUBLISHER_KEYS
         );
     }
 

--- a/src/test/java/org/atlasapi/persistence/content/MessageQueueingContentWriterTest.java
+++ b/src/test/java/org/atlasapi/persistence/content/MessageQueueingContentWriterTest.java
@@ -1,13 +1,10 @@
 package org.atlasapi.persistence.content;
 
+import com.google.common.primitives.Longs;
+import com.metabroadcast.common.queue.MessageSender;
 import org.atlasapi.media.entity.Episode;
 import org.atlasapi.media.entity.Publisher;
-import org.atlasapi.messaging.v3.ContentEquivalenceAssertionMessenger;
 import org.atlasapi.messaging.v3.EntityUpdatedMessage;
-
-import com.metabroadcast.common.queue.MessageSender;
-
-import com.google.common.primitives.Longs;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -27,10 +24,8 @@ public class MessageQueueingContentWriterTest {
         (MessageSender<EntityUpdatedMessage>) mock(MessageSender.class);
     private final ContentWriter delegate = mock(ContentWriter.class);
     private final ContentResolver resolver = mock(ContentResolver.class);
-    private final ContentEquivalenceAssertionMessenger messenger =
-            mock(ContentEquivalenceAssertionMessenger.class);
     private final MessageQueueingContentWriter writer 
-        = new MessageQueueingContentWriter(messenger, sender, delegate, resolver);
+        = new MessageQueueingContentWriter(sender, delegate, resolver);
     
     @Test
     public void testEnqueuesMessageWhenContentChanges() throws Exception {


### PR DESCRIPTION
This is so that the messaging can be consolidated in a single location with full view of the underlying lookup entry, allowing us to factor in blacklisted links in addition to both explicit and direct equivs.

Removed usage in MessageQueueingContentWriters as a result.