### PR TITLE
Internal equivalence messaging (ENG-816)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-persistence</artifactId>
-    <version>5.1-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
     <build>
         <finalName>atlas-persistence</finalName>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-persistence</artifactId>
-    <version>5.0-SNAPSHOT</version>
+    <version>5.1-SNAPSHOT</version>
     <build>
         <finalName>atlas-persistence</finalName>
         <plugins>

--- a/src/main/java/org/atlasapi/messaging/v3/EquivalenceChangeMessage.java
+++ b/src/main/java/org/atlasapi/messaging/v3/EquivalenceChangeMessage.java
@@ -85,11 +85,6 @@ public class EquivalenceChangeMessage extends AbstractMessage {
         return Sets.union(outgoingIdsAdded, outgoingIdsRemoved);
     }
 
-    @JsonIgnore
-    public Set<Long> getOutgoingIds() {
-        return Sets.union(outgoingIdsUnchanged, getOutgoingIdsChanged());
-    }
-
     public Set<String> getSources() {
         return sources;
     }

--- a/src/main/java/org/atlasapi/messaging/v3/EquivalenceChangeMessage.java
+++ b/src/main/java/org/atlasapi/messaging/v3/EquivalenceChangeMessage.java
@@ -1,0 +1,91 @@
+package org.atlasapi.messaging.v3;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.metabroadcast.common.queue.AbstractMessage;
+import com.metabroadcast.common.time.Timestamp;
+
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * <p>
+ * Message listing the change in equivalence on a particular subject for specified sources.
+ * </p>
+ */
+public class EquivalenceChangeMessage extends AbstractMessage {
+
+    private final long subjectId;
+    private Set<Long> outgoingIdsAdded;
+    private Set<Long> outgoingIdsRemoved;
+    private Set<Long> outgoingIdsUnchanged;
+    private Set<String> sources;
+
+    /**
+     * Creates a new {@link EquivalenceChangeMessage}.
+     *
+     * @param messageId
+     *            - a unique identifier for this message.
+     * @param timestamp
+     *            - the time this message was created.
+     * @param subjectId
+     *            - the id of the <i>subject</i> of this message.
+     * @param outgoingIdsAdded
+     *            - set of ids added as outgoing links from the <i>subject</i>.
+     * @param outgoingIdsRemoved
+     *            - set of ids removed as outgoing links from the <i>subject</i>.
+     * @param outgoingIdsUnchanged
+     *            - set of ids which existed as outgoing links from the <i>subject</i> and were unchanged.
+     * @param sources
+     *            - set of keys of sources for which these changes relate to.
+     */
+    public EquivalenceChangeMessage(
+            String messageId,
+            Timestamp timestamp,
+            Long subjectId,
+            Set<Long> outgoingIdsAdded,
+            Set<Long> outgoingIdsRemoved,
+            Set<Long> outgoingIdsUnchanged,
+            Set<String> sources
+    ) {
+        super(messageId, timestamp);
+        this.subjectId = checkNotNull(subjectId);
+        this.outgoingIdsAdded = ImmutableSet.copyOf(outgoingIdsAdded);
+        this.outgoingIdsRemoved = ImmutableSet.copyOf(outgoingIdsRemoved);
+        this.outgoingIdsUnchanged = ImmutableSet.copyOf(outgoingIdsUnchanged);
+        this.sources = ImmutableSet.copyOf(sources);
+    }
+
+    public long getSubjectId() {
+        return subjectId;
+    }
+
+    public Set<Long> getOutgoingIdsAdded() {
+        return outgoingIdsAdded;
+    }
+
+    public Set<Long> getOutgoingIdsRemoved() {
+        return outgoingIdsRemoved;
+    }
+
+    public Set<Long> getOutgoingIdsUnchanged() {
+        return outgoingIdsUnchanged;
+    }
+
+    @JsonIgnore
+    public Set<Long> getOutgoingIdsChanged() {
+        return Sets.union(outgoingIdsAdded, outgoingIdsRemoved);
+    }
+
+    @JsonIgnore
+    public Set<Long> getOutgoingIds() {
+        return Sets.union(outgoingIdsUnchanged, getOutgoingIdsChanged());
+    }
+
+    public Set<String> getSources() {
+        return sources;
+    }
+
+}

--- a/src/main/java/org/atlasapi/messaging/v3/EquivalenceChangeMessage.java
+++ b/src/main/java/org/atlasapi/messaging/v3/EquivalenceChangeMessage.java
@@ -8,8 +8,6 @@ import com.metabroadcast.common.time.Timestamp;
 
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * <p>
  * Message listing the change in equivalence on a particular subject for specified sources.
@@ -44,14 +42,14 @@ public class EquivalenceChangeMessage extends AbstractMessage {
     public EquivalenceChangeMessage(
             String messageId,
             Timestamp timestamp,
-            Long subjectId,
+            long subjectId,
             Set<Long> outgoingIdsAdded,
             Set<Long> outgoingIdsRemoved,
             Set<Long> outgoingIdsUnchanged,
             Set<String> sources
     ) {
         super(messageId, timestamp);
-        this.subjectId = checkNotNull(subjectId);
+        this.subjectId = subjectId;
         this.outgoingIdsAdded = ImmutableSet.copyOf(outgoingIdsAdded);
         this.outgoingIdsRemoved = ImmutableSet.copyOf(outgoingIdsRemoved);
         this.outgoingIdsUnchanged = ImmutableSet.copyOf(outgoingIdsUnchanged);

--- a/src/main/java/org/atlasapi/messaging/v3/EquivalenceChangeMessage.java
+++ b/src/main/java/org/atlasapi/messaging/v3/EquivalenceChangeMessage.java
@@ -50,10 +50,18 @@ public class EquivalenceChangeMessage extends AbstractMessage {
     ) {
         super(messageId, timestamp);
         this.subjectId = subjectId;
-        this.outgoingIdsAdded = ImmutableSet.copyOf(outgoingIdsAdded);
-        this.outgoingIdsRemoved = ImmutableSet.copyOf(outgoingIdsRemoved);
-        this.outgoingIdsUnchanged = ImmutableSet.copyOf(outgoingIdsUnchanged);
-        this.sources = ImmutableSet.copyOf(sources);
+        this.outgoingIdsAdded = outgoingIdsAdded == null
+                ? ImmutableSet.of()
+                : ImmutableSet.copyOf(outgoingIdsAdded);
+        this.outgoingIdsRemoved = outgoingIdsRemoved == null
+                ? ImmutableSet.of()
+                : ImmutableSet.copyOf(outgoingIdsRemoved);
+        this.outgoingIdsUnchanged = outgoingIdsUnchanged == null
+                ? ImmutableSet.of()
+                : ImmutableSet.copyOf(outgoingIdsUnchanged);
+        this.sources = sources == null
+                ? ImmutableSet.of()
+                : ImmutableSet.copyOf(sources);
     }
 
     public long getSubjectId() {

--- a/src/main/java/org/atlasapi/messaging/v3/EquivalenceChangeMessenger.java
+++ b/src/main/java/org/atlasapi/messaging/v3/EquivalenceChangeMessenger.java
@@ -1,0 +1,141 @@
+package org.atlasapi.messaging.v3;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Longs;
+import com.metabroadcast.common.queue.MessageSender;
+import com.metabroadcast.common.time.Timestamp;
+import com.metabroadcast.common.time.Timestamper;
+import org.atlasapi.media.entity.LookupRef;
+import org.atlasapi.persistence.lookup.entry.EquivRefs;
+import org.atlasapi.persistence.lookup.entry.LookupEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class EquivalenceChangeMessenger {
+
+    private static final Logger log = LoggerFactory
+            .getLogger(EquivalenceChangeMessenger.class);
+
+    private final MessageSender<EquivalenceChangeMessage> sender;
+    private final Timestamper timestamper;
+
+    private EquivalenceChangeMessenger(
+            MessageSender<EquivalenceChangeMessage> sender,
+            Timestamper timestamper
+    ) {
+        this.sender = checkNotNull(sender);
+        this.timestamper = checkNotNull(timestamper);
+    }
+
+    public static EquivalenceChangeMessenger create(
+            MessageSender<EquivalenceChangeMessage> sender,
+            Timestamper timestamper
+    ) {
+        return new EquivalenceChangeMessenger(sender, timestamper);
+    }
+
+    public void sendMessageFromDirectEquivs(
+            LookupEntry existingSubjectEntry,
+            LookupEntry newSubjectEntry,
+            Set<String> sources
+    ) {
+        ImmutableSet.Builder<Long> added = ImmutableSet.builder();
+        ImmutableSet.Builder<Long> removed = ImmutableSet.builder();
+        ImmutableSet.Builder<Long> unchanged = ImmutableSet.builder();
+
+        for (LookupRef ref : existingSubjectEntry.directEquivalents().getOutgoing()) {
+            if (newSubjectEntry.directEquivalents().contains(ref, EquivRefs.Direction.OUTGOING)) {
+                unchanged.add(ref.id());
+            } else {
+                if (!sources.contains(ref.publisher().key())) {
+                    log.warn(
+                            "Subject {} removed {} which did not belong to {}",
+                            new Object[]{newSubjectEntry.uri(), ref.uri(), sources}
+                    );
+                }
+                removed.add(ref.id());
+            }
+        }
+
+        for (LookupRef ref : newSubjectEntry.directEquivalents().getOutgoing()) {
+            if (!existingSubjectEntry.directEquivalents().contains(ref, EquivRefs.Direction.OUTGOING)) {
+                added.add(ref.id());
+                if (!sources.contains(ref.publisher().key())) {
+                    log.warn(
+                            "Subject {} added {} which did not belong to {}",
+                            new Object[]{newSubjectEntry.uri(), ref.uri(), sources}
+                    );
+                }
+            }
+        }
+
+        sendMessage(
+                newSubjectEntry,
+                added.build(),
+                removed.build(),
+                unchanged.build(),
+                sources
+        );
+    }
+
+    public void sendMessage(
+            LookupEntry subject,
+            Set<Long> outgoingIdsAdded,
+            Set<Long> outgoingIdsRemoved,
+            Set<Long> outgoingIdsUnchanged,
+            Set<String> sources
+    ) {
+        try {
+            String messageId = UUID.randomUUID().toString();
+            Timestamp timestamp = timestamper.timestamp();
+            EquivalenceChangeMessage message = new EquivalenceChangeMessage(
+                    messageId,
+                    timestamp,
+                    subject.id(),
+                    outgoingIdsAdded,
+                    outgoingIdsRemoved,
+                    outgoingIdsUnchanged,
+                    sources
+            );
+
+            sender.sendMessage(
+                    message,
+                    getMessagePartitionKey(subject)
+            );
+        } catch (Exception e) {
+            log.error("Failed to send equiv result message: " + subject, e);
+        }
+    }
+
+
+    private byte[] getMessagePartitionKey(LookupEntry lookupEntry) {
+
+        // Given most of the time the equivalence results do not change the existing graph
+        // (due to the fact that we are often rerunning equivalence on the same items with
+        // the same results) the underlying graph will remain unchanged. Therefore if we get
+        // the smallest lookup entry ID from that graph that ID should be consistent enough
+        // to use as a partition key and ensure updates on the same graph end up on the same
+        // partition.
+        Optional<Long> graphId = Stream.concat(
+                lookupEntry.equivalents().stream(),
+                lookupEntry.getNeighbours().stream()
+        )
+                .map(LookupRef::id)
+                .sorted()
+                .findFirst();
+
+        if (graphId.isPresent()) {
+            return Longs.toByteArray(graphId.get());
+        }
+
+        // Default to returning the subject ID as the partition key
+        return Longs.toByteArray(lookupEntry.id());
+    }
+}

--- a/src/main/java/org/atlasapi/messaging/v3/JacksonMessageSerializer.java
+++ b/src/main/java/org/atlasapi/messaging/v3/JacksonMessageSerializer.java
@@ -23,8 +23,6 @@ import org.atlasapi.messaging.worker.v3.EntityUpdatedMessageConfiguration;
 import org.atlasapi.messaging.worker.v3.EquivalenceChangeMessageConfiguration;
 import org.atlasapi.messaging.worker.v3.ScheduleUpdateMessageConfiguration;
 import org.atlasapi.serialization.json.JsonFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -32,7 +30,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class JacksonMessageSerializer<M extends Message> implements MessageSerializer<M> {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
 
     public static final <M extends Message> JacksonMessageSerializer<M> forType(Class<? extends M> cls) {
         return new JacksonMessageSerializer<>(cls);
@@ -179,8 +176,6 @@ public class JacksonMessageSerializer<M extends Message> implements MessageSeria
         try {
             return mapper.readValue(serialized, cls);
         } catch (IOException e) {
-            String message = new String(serialized);
-            log.warn("Message failed to be deserialized: {}", message, e);
             throw new MessageDeserializationException(e);
         }
     }

--- a/src/main/java/org/atlasapi/messaging/v3/JacksonMessageSerializer.java
+++ b/src/main/java/org/atlasapi/messaging/v3/JacksonMessageSerializer.java
@@ -1,20 +1,5 @@
 package org.atlasapi.messaging.v3;
 
-import java.io.IOException;
-
-import org.atlasapi.messaging.v3.ContentEquivalenceAssertionMessage.AdjacentRef;
-import org.atlasapi.messaging.worker.v3.AdjacentRefConfiguration;
-import org.atlasapi.messaging.worker.v3.ContentEquivalenceAssertionMessageConfiguration;
-import org.atlasapi.messaging.worker.v3.EntityUpdatedMessageConfiguration;
-import org.atlasapi.messaging.worker.v3.ScheduleUpdateMessageConfiguration;
-import org.atlasapi.serialization.json.JsonFactory;
-
-import com.metabroadcast.common.queue.Message;
-import com.metabroadcast.common.queue.MessageDeserializationException;
-import com.metabroadcast.common.queue.MessageSerializationException;
-import com.metabroadcast.common.queue.MessageSerializer;
-import com.metabroadcast.common.time.Timestamp;
-
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -26,6 +11,20 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.common.base.Objects;
+import com.metabroadcast.common.queue.Message;
+import com.metabroadcast.common.queue.MessageDeserializationException;
+import com.metabroadcast.common.queue.MessageSerializationException;
+import com.metabroadcast.common.queue.MessageSerializer;
+import com.metabroadcast.common.time.Timestamp;
+import org.atlasapi.messaging.v3.ContentEquivalenceAssertionMessage.AdjacentRef;
+import org.atlasapi.messaging.worker.v3.AdjacentRefConfiguration;
+import org.atlasapi.messaging.worker.v3.ContentEquivalenceAssertionMessageConfiguration;
+import org.atlasapi.messaging.worker.v3.EntityUpdatedMessageConfiguration;
+import org.atlasapi.messaging.worker.v3.EquivalenceChangeMessageConfiguration;
+import org.atlasapi.messaging.worker.v3.ScheduleUpdateMessageConfiguration;
+import org.atlasapi.serialization.json.JsonFactory;
+
+import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -137,6 +136,8 @@ public class JacksonMessageSerializer<M extends Message> implements MessageSeria
             );
             context.setMixInAnnotations(AdjacentRef.class, AdjacentRefConfiguration.class);
 
+            context.setMixInAnnotations(EquivalenceChangeMessage.class, EquivalenceChangeMessageConfiguration.class);
+
             SimpleDeserializers deserializers = new SimpleDeserializers();
             deserializers.addDeserializer(Timestamp.class, new TimestampDeserializer());
             context.addDeserializers(deserializers);
@@ -145,6 +146,7 @@ public class JacksonMessageSerializer<M extends Message> implements MessageSeria
                     ScheduleUpdateMessage.class,
                     ScheduleUpdateMessageConfiguration.class
             );
+
         }
     }
     

--- a/src/main/java/org/atlasapi/messaging/v3/JacksonMessageSerializer.java
+++ b/src/main/java/org/atlasapi/messaging/v3/JacksonMessageSerializer.java
@@ -23,12 +23,16 @@ import org.atlasapi.messaging.worker.v3.EntityUpdatedMessageConfiguration;
 import org.atlasapi.messaging.worker.v3.EquivalenceChangeMessageConfiguration;
 import org.atlasapi.messaging.worker.v3.ScheduleUpdateMessageConfiguration;
 import org.atlasapi.serialization.json.JsonFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class JacksonMessageSerializer<M extends Message> implements MessageSerializer<M> {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     public static final <M extends Message> JacksonMessageSerializer<M> forType(Class<? extends M> cls) {
         return new JacksonMessageSerializer<>(cls);
@@ -175,6 +179,8 @@ public class JacksonMessageSerializer<M extends Message> implements MessageSeria
         try {
             return mapper.readValue(serialized, cls);
         } catch (IOException e) {
+            String message = new String(serialized);
+            log.warn("Message failed to be deserialized: {}", message, e);
             throw new MessageDeserializationException(e);
         }
     }

--- a/src/main/java/org/atlasapi/messaging/worker/v3/EquivalenceChangeMessageConfiguration.java
+++ b/src/main/java/org/atlasapi/messaging/worker/v3/EquivalenceChangeMessageConfiguration.java
@@ -1,0 +1,22 @@
+package org.atlasapi.messaging.worker.v3;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.metabroadcast.common.time.Timestamp;
+
+import java.util.Set;
+
+public abstract class EquivalenceChangeMessageConfiguration {
+
+    @JsonCreator
+    EquivalenceChangeMessageConfiguration(
+            @JsonProperty("messageId") String messageId,
+            @JsonProperty("timestamp") Timestamp timestamp,
+            @JsonProperty("subjectId") long subjectId,
+            @JsonProperty("outgoingIdsAdded") Set<Long> outgoingIdsAdded,
+            @JsonProperty("outgoingIdsRemoved") Set<Long> outgoingIdsRemoved,
+            @JsonProperty("outgoingIdsUnchanged") Set<Long> outgoingIdsUnchanged,
+            @JsonProperty("sources") Set<String> sources
+    ) {
+    }
+}

--- a/src/main/java/org/atlasapi/persistence/MongoContentPersistenceModule.java
+++ b/src/main/java/org/atlasapi/persistence/MongoContentPersistenceModule.java
@@ -90,6 +90,7 @@ public class MongoContentPersistenceModule implements ContentPersistenceModule {
     @Value("${messaging.destination.event.changes}") private String eventChanges;
     @Value("${messaging.destination.organisation.changes}") private String organisationChanges;
     @Value("${messaging.destination.equiv.assert}") private String equivAssertDest;
+    @Value("${messaging.destination.equiv.changes.content}") private String equivChangesContentDest;
     @Value("${messaging.enabled}") private String messagingEnabled;
     @Value("${mongo.audit.dbname}") private String auditDbName;
     @Value("${mongo.audit.enabled}") private boolean auditEnabled;
@@ -145,7 +146,8 @@ public class MongoContentPersistenceModule implements ContentPersistenceModule {
                 Boolean.valueOf(messagingEnabled),
                 false,
                 processingConfig,
-                equivAssertDest
+                equivAssertDest,
+                equivChangesContentDest
         );
     }
 

--- a/src/test/java/org/atlasapi/messaging/v3/EquivalenceChangeMessageTest.java
+++ b/src/test/java/org/atlasapi/messaging/v3/EquivalenceChangeMessageTest.java
@@ -3,12 +3,20 @@ package org.atlasapi.messaging.v3;
 import com.google.common.collect.ImmutableSet;
 import com.metabroadcast.common.time.Timestamp;
 import org.atlasapi.media.entity.Publisher;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 
 public class EquivalenceChangeMessageTest {
+
+    private JacksonMessageSerializer<EquivalenceChangeMessage> serializer;
+
+    @Before
+    public void setUp() throws Exception {
+        serializer = JacksonMessageSerializer.forType(EquivalenceChangeMessage.class);
+    }
 
     @Test
     public void testDeSerialization() throws Exception {
@@ -23,8 +31,38 @@ public class EquivalenceChangeMessageTest {
                 ImmutableSet.of(Publisher.TESTING_MBST.key(), Publisher.BBC.key())
 
         );
-        JacksonMessageSerializer<EquivalenceChangeMessage> serializer =
-                JacksonMessageSerializer.forType(EquivalenceChangeMessage.class);
+
+        byte[] serialized = serializer.serialize(msg);
+
+        EquivalenceChangeMessage deserialized
+                = serializer.deserialize(serialized);
+
+        assertEquals(msg.getMessageId(), deserialized.getMessageId());
+        assertEquals(msg.getTimestamp(), deserialized.getTimestamp());
+        assertEquals(msg.getSubjectId(), deserialized.getSubjectId());
+        assertEquals(msg.getOutgoingIdsAdded(), deserialized.getOutgoingIdsAdded());
+        assertEquals(msg.getOutgoingIdsRemoved(), deserialized.getOutgoingIdsRemoved());
+        assertEquals(msg.getOutgoingIdsUnchanged(), deserialized.getOutgoingIdsUnchanged());
+        assertEquals(msg.getSources(), deserialized.getSources());
+
+        assertEquals(msg.getOutgoingIdsChanged(), deserialized.getOutgoingIdsChanged());
+    }
+
+
+    // Empty set fields are not included in serialization
+    @Test
+    public void testDeSerializationOfEmptyCollections() throws Exception {
+
+        EquivalenceChangeMessage msg = new EquivalenceChangeMessage(
+                "id",
+                Timestamp.of(0L),
+                1L,
+                ImmutableSet.of(),
+                ImmutableSet.of(),
+                ImmutableSet.of(),
+                ImmutableSet.of()
+
+        );
 
         byte[] serialized = serializer.serialize(msg);
 

--- a/src/test/java/org/atlasapi/messaging/v3/EquivalenceChangeMessageTest.java
+++ b/src/test/java/org/atlasapi/messaging/v3/EquivalenceChangeMessageTest.java
@@ -1,0 +1,47 @@
+package org.atlasapi.messaging.v3;
+
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.time.Timestamp;
+import org.atlasapi.media.entity.Publisher;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class EquivalenceChangeMessageTest {
+
+    @Test
+    public void testDeSerialization() throws Exception {
+
+        EquivalenceChangeMessage msg = new EquivalenceChangeMessage(
+                "id",
+                Timestamp.of(0L),
+                1L,
+                ImmutableSet.of(2L, 3L),
+                ImmutableSet.of(4L, 5L),
+                ImmutableSet.of(6L, 7L),
+                ImmutableSet.of(Publisher.TESTING_MBST.key(), Publisher.BBC.key())
+
+        );
+        JacksonMessageSerializer<EquivalenceChangeMessage> serializer =
+                JacksonMessageSerializer.forType(EquivalenceChangeMessage.class);
+
+        byte[] serialized = serializer.serialize(msg);
+
+        EquivalenceChangeMessage deserialized
+                = serializer.deserialize(serialized);
+
+        assertEquals(msg.getMessageId(), deserialized.getMessageId());
+        assertEquals(msg.getTimestamp(), deserialized.getTimestamp());
+        assertEquals(msg.getSubjectId(), deserialized.getSubjectId());
+        assertEquals(msg.getOutgoingIdsAdded(), deserialized.getOutgoingIdsAdded());
+        assertEquals(msg.getOutgoingIdsRemoved(), deserialized.getOutgoingIdsRemoved());
+        assertEquals(msg.getOutgoingIdsUnchanged(), deserialized.getOutgoingIdsUnchanged());
+        assertEquals(msg.getSources(), deserialized.getSources());
+
+        assertEquals(msg.getOutgoingIdsChanged(), deserialized.getOutgoingIdsChanged());
+        assertEquals(msg.getOutgoingIds(), deserialized.getOutgoingIds());
+
+    }
+
+}

--- a/src/test/java/org/atlasapi/messaging/v3/EquivalenceChangeMessageTest.java
+++ b/src/test/java/org/atlasapi/messaging/v3/EquivalenceChangeMessageTest.java
@@ -40,8 +40,6 @@ public class EquivalenceChangeMessageTest {
         assertEquals(msg.getSources(), deserialized.getSources());
 
         assertEquals(msg.getOutgoingIdsChanged(), deserialized.getOutgoingIdsChanged());
-        assertEquals(msg.getOutgoingIds(), deserialized.getOutgoingIds());
-
     }
 
 }

--- a/src/test/java/org/atlasapi/messaging/v3/EquivalenceChangeMessengerTest.java
+++ b/src/test/java/org/atlasapi/messaging/v3/EquivalenceChangeMessengerTest.java
@@ -1,0 +1,129 @@
+package org.atlasapi.messaging.v3;
+
+import com.google.common.collect.ImmutableSet;
+import com.metabroadcast.common.queue.MessageSender;
+import com.metabroadcast.common.time.Timestamp;
+import com.metabroadcast.common.time.Timestamper;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.LookupRef;
+import org.atlasapi.media.entity.Publisher;
+import org.atlasapi.persistence.content.ContentCategory;
+import org.atlasapi.persistence.lookup.entry.EquivRefs;
+import org.atlasapi.persistence.lookup.entry.LookupEntry;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EquivalenceChangeMessengerTest {
+    private final MessageSender<EquivalenceChangeMessage> sender = mock(MessageSender.class);
+    private final Timestamper timestamper = mock(Timestamper.class);
+    private EquivalenceChangeMessenger equivalenceChangeMessenger;
+
+    @Before
+    public void setUp() throws Exception {
+        equivalenceChangeMessenger = EquivalenceChangeMessenger.create(
+                sender,
+                timestamper
+        );
+    }
+
+    @Test
+    public void todo() throws Exception {
+
+        Item item1 = item(1);
+        LookupRef ref2 = ref(2);
+        LookupRef ref3 = ref(3);
+        LookupRef ref4 = ref(4);
+
+        LookupEntry original = LookupEntry.lookupEntryFrom(item1);
+        original = original.copyWithDirectEquivalents(
+                original.directEquivalents()
+                        .copyWithLinks(ImmutableSet.of(ref2, ref3), EquivRefs.Direction.OUTGOING)
+        );
+
+        LookupEntry updated = original.copyWithDirectEquivalents(
+                original.directEquivalents()
+                        .copyWithoutLink(ref3, EquivRefs.Direction.OUTGOING)
+                        .copyWithLink(ref4, EquivRefs.Direction.OUTGOING)
+        );
+
+        Set<String> sources = ImmutableSet.of(Publisher.TESTING_MBST.key());
+
+        when(timestamper.timestamp()).thenReturn(Timestamp.of(1L));
+
+        equivalenceChangeMessenger.sendMessageFromDirectEquivs(original, updated, sources);
+
+        verify(sender, times(1)).sendMessage(
+                argThat(messageMatcher(
+                        item1.getId(),
+                        ImmutableSet.of(ref4.id()),
+                        ImmutableSet.of(ref3.id()),
+                        ImmutableSet.of(item1.getId(), ref2.id()),
+                        sources
+                )),
+                any()
+        );
+    }
+
+    private Item item(long id) {
+        Item item = new Item();
+        item.setCanonicalUri("uri" + id);
+        item.setId(id);
+        item.setPublisher(Publisher.TESTING_MBST);
+        return item;
+    }
+
+    private LookupRef ref(long id) {
+        return new LookupRef("uri" + id, id, Publisher.TESTING_MBST, ContentCategory.TOP_LEVEL_ITEM);
+    }
+
+
+
+    private static Matcher<EquivalenceChangeMessage> messageMatcher(
+            long subjectId,
+            Set<Long> outgoingIdsAdded,
+            Set<Long> outgoingIdsRemoved,
+            Set<Long> outgoingIdsUnchanged,
+            Set<String> sources
+    ) {
+        return new BaseMatcher<EquivalenceChangeMessage>() {
+            @Override
+            public boolean matches(Object o) {
+                if (!(o instanceof EquivalenceChangeMessage)) {
+                    return false;
+                }
+
+                EquivalenceChangeMessage msg = (EquivalenceChangeMessage) o;
+                return msg.getSubjectId() == subjectId
+                        && msg.getOutgoingIdsAdded().equals(outgoingIdsAdded)
+                        && msg.getOutgoingIdsRemoved().equals(outgoingIdsRemoved)
+                        && msg.getOutgoingIdsUnchanged().equals(outgoingIdsUnchanged)
+                        && msg.getSources().equals(sources);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(
+                        "EquivalenceChangeMessage for:" +
+                                "\nsubjectId: " + subjectId +
+                                "\noutgoingIdsAdded: " + outgoingIdsAdded +
+                                "\noutgoingIdsRemoved: " + outgoingIdsRemoved +
+                                "\noutgoingIdsUnchanged: " + outgoingIdsUnchanged +
+                                "\nsources: " + sources
+
+                );
+            }
+        };
+    }
+}

--- a/src/test/java/org/atlasapi/messaging/v3/EquivalenceChangeMessengerTest.java
+++ b/src/test/java/org/atlasapi/messaging/v3/EquivalenceChangeMessengerTest.java
@@ -39,7 +39,7 @@ public class EquivalenceChangeMessengerTest {
     }
 
     @Test
-    public void todo() throws Exception {
+    public void testCorrectChangesAreDeterminedFromLookupEntries() throws Exception {
 
         Item item1 = item(1);
         LookupRef ref2 = ref(2);

--- a/src/test/java/org/atlasapi/persistence/ConstructorBasedMongoContentPersistenceModuleIT.java
+++ b/src/test/java/org/atlasapi/persistence/ConstructorBasedMongoContentPersistenceModuleIT.java
@@ -134,7 +134,8 @@ public class ConstructorBasedMongoContentPersistenceModuleIT {
                 true,
                 true,
                 Parameter.valueOf("false"),
-                "EquivAssert"
+                "EquivAssert",
+                "EquivChangesContent"
         );
 
         moduleWithProcessingConfigTrue = new ConstructorBasedMongoContentPersistenceModule(
@@ -154,7 +155,8 @@ public class ConstructorBasedMongoContentPersistenceModuleIT {
                 true,
                 true,
                 Parameter.valueOf("true"),
-                "EquivAssert"
+                "EquivAssert",
+                "EquivChangesContent"
         );
 
     }

--- a/src/test/java/org/atlasapi/persistence/lookup/TransitiveLookupWriterTest.java
+++ b/src/test/java/org/atlasapi/persistence/lookup/TransitiveLookupWriterTest.java
@@ -49,6 +49,7 @@ import static org.atlasapi.persistence.lookup.entry.LookupEntry.lookupEntryFrom;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -625,7 +626,7 @@ public class TransitiveLookupWriterTest extends TestCase {
         );
         verify(changesMessenger, times(1)).sendMessageFromDirectEquivs(
                 argThat(is(initialPaEntry)),
-                argThat(lookupEntryMatcher(paItem.getCanonicalUri())),
+                and(argThat(lookupEntryMatcher(paItem.getCanonicalUri())), argThat(not(initialPaEntry))),
                 argThat(is(sources))
         );
 


### PR DESCRIPTION
Due to asymmetric equivalence we can only break bidirectional equivalence links that should be broken by rerunning equiv on both pieces of content. As a result when equivalence changes a message is now sent listing which outgoing ids have changed so that equiv can be run on them.